### PR TITLE
Add support for References

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist/ --project-name=resumecorgi
+          command: pages deploy dist/ --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: 'npm'
 
       - name: Restore Dependencies
         run: npm ci
@@ -47,6 +50,9 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: 'npm'
 
       - name: Restore Dependencies
         run: npm ci
@@ -77,4 +83,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist/ --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }}
+          command: pages deploy dist/ --project-name=resumecorgi

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,9 @@
         "ts-jest": "^29.3.1",
         "typescript": "^5.8.3",
         "vite": "^6.2.6"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "ts-jest": "^29.3.1",
     "typescript": "^5.8.3",
     "vite": "^6.2.6"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/src/lib/DataInitializer.ts
+++ b/src/lib/DataInitializer.ts
@@ -7,6 +7,7 @@ export const initialSections: Section[] = [
   { id: 'education', displayName: 'Education', href: '#education', selected: true, originalOrder: 2, sortOrder: 2, required: false, sortable: true },
   { id: 'skills', displayName: 'Skills', href: '#skills', selected: true, originalOrder: 3, sortOrder: 3, required: false, sortable: true },
   { id: 'projects', displayName: 'Projects', href: '#projects', selected: true, originalOrder: 4, sortOrder: 4, required: false, sortable: true },
+  { id: "references", displayName: 'References', href: '#references', selected: true, originalOrder: 5, sortOrder: 5, required: false, sortable: true },
 ];
 
 export const createSectionsFromFormData = (formData: FormData): Section[] => {
@@ -49,6 +50,7 @@ export const initialFormData: FormData = {
   education: [],
   skills: [],
   projects: [],
+  references: [],
   genericSections: {}
 };
 
@@ -133,4 +135,13 @@ export const sampleFormData: FormData = {
       "url": "https://www.royalcorgitrainingacademy.com"
     }
   ],
+  "references": [
+    {
+      "name": "Her Majesty the Queen",
+      "company": "Buckingham Palace",
+      "title": "Royal Patron",
+      "contactPhone": "555-123-4567",
+      "contactEmail": "email@example.org"
+    }
+  ]
 };

--- a/src/lib/ImportExportService.ts
+++ b/src/lib/ImportExportService.ts
@@ -299,6 +299,7 @@ export const importFromJsonResume = (jsonResume: JsonResume): FormData => {
       highlights: createUnorderedList(project.highlights || []),
       url: project.url || ''
     })),
+    references: [],
   };
 
   // Find custom sections (any key not in standard sections)

--- a/src/lib/LaTeX/TemplateAdapter.ts
+++ b/src/lib/LaTeX/TemplateAdapter.ts
@@ -54,6 +54,8 @@ ${footer}`;
         return this.formatSkills();
       case 'projects':
         return this.formatProjects();
+      case 'references':
+        return this.formatReferences();
       default:
         // Check if it's a generic section
         if (this.formData.genericSections && this.formData.genericSections[sectionId]) {
@@ -72,5 +74,6 @@ ${footer}`;
   protected abstract formatEducation(): string;
   protected abstract formatSkills(): string;
   protected abstract formatProjects(): string;
+  protected abstract formatReferences(): string;
   protected abstract formatGenericSection(section: GenericSection): string;
 }

--- a/src/lib/LaTeX/templates/ClassicResume.ts
+++ b/src/lib/LaTeX/templates/ClassicResume.ts
@@ -405,6 +405,37 @@ ${highlights
     return `${sectionHeading}${projectEntries}`;
   }
 
+  protected formatReferences(): string {
+    const references = this.formData.references;
+    if (!references || !references.length) {
+      return '';
+    }
+
+    const sectionHeading = `\\section{References}`;
+
+    const referenceEntries = references.map((ref, index) => {
+      const name = ref.name || '';
+      const title = ref.title || '';
+      const company = ref.company || '';
+      const contactPhone = ref.contactPhone || '';
+      const contactEmail = ref.contactEmail || '';
+
+      const isLastItem = index === references.length - 1;
+      const spacingAfter = isLastItem ? '' : '\n\n        \\vspace{0.2 cm}\n';
+
+      const companyAndTitle = `${company ? company : ''}${company && title ? ' (' : ''}${title ? this.utils.escapeLaTeX(title) : ''}${company && title ? ')' : ''}`;
+      const contactLine = `${contactPhone ? this.utils.escapeLaTeX(contactPhone) : ''}${contactPhone && contactEmail ? ', ' : ''}${contactEmail ? this.utils.escapeLaTeX(contactEmail) : ''}`;
+
+      return `
+        \\begin{onecolentry}
+            \\textbf{${this.utils.escapeLaTeX(name)}}${companyAndTitle ? ',' : ''} ${this.utils.escapeLaTeX(companyAndTitle)} \\\\
+            ${this.utils.escapeLaTeX(contactLine)}
+        \\end{onecolentry}${spacingAfter}`;
+    }).join('');
+
+    return `${sectionHeading}${referenceEntries}`;
+  }
+
   protected formatGenericSection(section: GenericSection): string {
     if (!section || !section.items.length) {
       return '';

--- a/src/lib/LaTeX/templates/EngineeringResume.ts
+++ b/src/lib/LaTeX/templates/EngineeringResume.ts
@@ -161,6 +161,34 @@ ${this.utils.formatItemize(highlights, { vspaceBefore: '-9pt', vspaceAfter: '-3p
     }).join('\n\n');
   }
 
+  protected formatReferences(): string {
+    const references = this.formData.references;
+    if (!references || !references.length) {
+      return '';
+    }
+
+    const sectionHeading = `% references section
+\\section*{References}
+`;
+
+    return sectionHeading + references.map((ref, index) => {
+      const name = ref.name || '';
+      const title = ref.title || '';
+      const company = ref.company || '';
+      const contactPhone = ref.contactPhone || '';
+      const contactEmail = ref.contactEmail || '';
+
+      const companyAndTitle = `${company ? company : ''}${company && title ? ' (' : ''}${title ? this.utils.escapeLaTeX(title) : ''}${company && title ? ')' : ''}`;
+      const mainLine = `\\textbf{${this.utils.escapeLaTeX(name)}${companyAndTitle ? ',' : ''}} ${this.utils.escapeLaTeX(companyAndTitle)} \\\\`;
+      const contactLine = `${contactPhone ? `${this.utils.escapeLaTeX(contactPhone)}` : ''}${contactPhone && contactEmail ? ', ' : ''}${contactEmail ? `${this.utils.escapeLaTeX(contactEmail)}` : ''}`;
+      const isLastItem = index === references.length - 1;
+
+      return `${mainLine}
+${contactLine}
+\\vspace{${isLastItem ? '-9pt' : '-3pt'}}`;
+    }).join('\n\n');
+  }
+
   protected formatGenericSection(section: GenericSection): string {
     if (!section || !section.items.length) {
       return '';

--- a/src/lib/LaTeX/templates/EngineeringResume2.ts
+++ b/src/lib/LaTeX/templates/EngineeringResume2.ts
@@ -418,6 +418,37 @@ ${highlights}
     return `${sectionHeading}${projectEntries}`;
   }
 
+  protected formatReferences(): string {
+    const references = this.formData.references;
+    if (!references || !references.length) {
+      return '';
+    }
+
+    const sectionHeading = `\\section{References}`;
+
+    const educationEntries = references.map((ref, index) => {
+      const name = ref.name || '';
+      const title = ref.title || '';
+      const company = ref.company || '';
+      const contactPhone = ref.contactPhone || '';
+      const contactEmail = ref.contactEmail || '';
+
+      const isLastItem = index === references.length - 1;
+      const spacingAfter = isLastItem ? '' : '\n\n        \\vspace{0.2 cm}\n';
+
+      const companyAndTitle = `${company ? company : ''}${company && title ? ' (' : ''}${title ? this.utils.escapeLaTeX(title) : ''}${company && title ? ')' : ''}`;
+      const contactLine = `${contactPhone ? `${this.utils.escapeLaTeX(contactPhone)}` : ''}${contactPhone && contactEmail ? ', ' : ''}${contactEmail ? `${this.utils.escapeLaTeX(contactEmail)}` : ''}`;
+
+      return `
+        \\begin{onecolentry}
+            \\textbf{${this.utils.escapeLaTeX(name)}}${companyAndTitle ? ',' : ''} ${this.utils.escapeLaTeX(companyAndTitle)} \\\\
+            ${this.utils.escapeLaTeX(contactLine)}
+        \\end{onecolentry}${spacingAfter}`;
+    }).join('');
+
+    return `${sectionHeading}${educationEntries}`;
+  }
+
   protected formatGenericSection(section: GenericSection): string {
     if (!section || !section.items.length) {
       return '';

--- a/src/lib/LaTeXService.ts
+++ b/src/lib/LaTeXService.ts
@@ -1,4 +1,4 @@
-import { Experience, Education, Skill, FormData, Section, GenericSection, Project } from "../types";
+import { Experience, Education, Skill, FormData, Section, GenericSection, Project, Reference } from "../types";
 
 /**
  * Resume LaTeX Generator
@@ -245,6 +245,34 @@ ${this.utils.formatItemize(highlights, { vspaceBefore: '-9pt', vspaceAfter: '-3p
     }).join('\n\n');
   }
 
+  formatReferences(references?: Reference[]): string {
+    if (!references || !references.length) {
+      return '';
+    }
+
+    const sectionHeading = `% references section
+    \\section*{References}
+    `;
+
+    return sectionHeading + references.map((ref, index) => {
+      const name = ref.name || '';
+      const title = ref.title || '';
+      const company = ref.company || '';
+      const contactPhone = ref.contactPhone || '';
+      const contactEmail = ref.contactEmail || '';
+
+      const isLastItem = index === references.length - 1;
+
+      const companyAndTitle = `${company ? company : ''}${company && title ? ' (' : ''}${title ? this.utils.escapeLaTeX(title) : ''}${company && title ? ')' : ''}`;
+      const contactLine = `${contactPhone ? this.utils.escapeLaTeX(contactPhone) : ''}${contactPhone && contactEmail ? ', ' : ''}${contactEmail ? this.utils.escapeLaTeX(contactEmail) : ''}`;
+
+      return `% references details
+    \\textbf{${name}${companyAndTitle ? ',' : ''}} ${this.utils.escapeLaTeX(companyAndTitle)} \\\\
+    ${contactLine}
+    \\vspace{${isLastItem ? '-9pt' : '-3pt'}}`;
+    }).join('\n\n');
+  }
+
   formatGenericSection(section: GenericSection): string {
     if (!section || !section.items.length) {
       return '';
@@ -344,7 +372,8 @@ class LaTeXResumeGenerator {
       experience: this.formatters.formatExperience.bind(this.formatters),
       education: this.formatters.formatEducation.bind(this.formatters),
       skills: this.formatters.formatSkills.bind(this.formatters),
-      projects: this.formatters.formatProjects.bind(this.formatters)
+      projects: this.formatters.formatProjects.bind(this.formatters),
+      references: this.formatters.formatReferences.bind(this.formatters),
     };
 
     this.templateRegistry.register('standard', defaultTemplate);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,6 +55,14 @@ export interface Project {
   url: string;
 }
 
+export interface Reference {
+  name: string;
+  title: string;
+  company: string;
+  contactEmail: string;
+  contactPhone: string;
+}
+
 export interface GenericSection {
   title: string;
   items: {
@@ -72,6 +80,7 @@ export interface FormData {
   education: Education[];
   skills: Skill[];
   projects: Project[];
+  references: Reference[];
   genericSections?: { [key: string]: GenericSection };
 }
 

--- a/src/views/Editor.tsx
+++ b/src/views/Editor.tsx
@@ -16,6 +16,7 @@ import Projects from './forms/Projects';
 import GenericSection from './forms/GenericSection';
 import { downloadResumeAsJson } from '@/lib/ImportExportService';
 import { useResume } from '@/lib/ResumeContext';
+import Reference from './forms/Reference';
 
 interface SectionRenderItem {
   id: string;
@@ -84,6 +85,16 @@ function Editor() {
         <>
           <Card>
             <Projects />
+          </Card>
+        </>
+    },
+    {
+      id: 'references',
+      title: 'References',
+      renderFunc: () =>
+        <>
+          <Card>
+            <Reference />
           </Card>
         </>
     },

--- a/src/views/forms/Reference.tsx
+++ b/src/views/forms/Reference.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import Button from '../../components/Button';
+import Input from '../../components/Input';
+import { FormData, Reference as ReferenceInfo } from '../../types';
+import Separator from '../../components/Separator';
+import { useResume } from '@/lib/ResumeContext';
+
+function Reference() {
+  const { formData, setFormData } = useResume();
+  const references = formData.references;
+
+  const addReference = (): void => {
+    const newReference: ReferenceInfo = {
+      name: '',
+      title: '',
+      company: '',
+      contactEmail: '',
+      contactPhone: ''
+    };
+
+    setFormData({
+      ...formData,
+      references: [...references, newReference]
+    });
+  };
+
+  const removeReference = (index: number): void => {
+    const updatedReference = [...references];
+    updatedReference.splice(index, 1);
+    setFormData({
+      ...formData,
+      references: updatedReference
+    });
+  };
+
+  const updateReference = (index: number, field: keyof ReferenceInfo, value: string): void => {
+    const updatedReference = { ...references[index], [field]: value };
+    const updatedReferences = [...references];
+    updatedReferences[index] = updatedReference;
+    setFormData({
+      ...formData,
+      references: updatedReferences
+    });
+  };
+
+  return (
+    <>
+      <div className="flex items-center -mt-1 mb-2">
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2" id="references">References</h2>
+      </div>
+      <p className="hidden text-slate-800 mb-4 dark:text-gray-200 mb-6 w-2/3">
+        Let's add your references.
+      </p>
+
+      {references.map((ref, index) => (
+        <div key={index} className="mb-3">
+          {index !== 0 && index !== references.length && (
+            <Separator />
+          )}
+          <h3 className="text-medium font-bold mb-1.5 text-gray-900 dark:text-gray-200">
+            {`Reference #${index + 1}`}
+            {index >= 0 && (
+              <>
+                <span className="ms-3"></span>
+                <Button
+                  text="Remove"
+                  onClick={() => removeReference(index)}
+                  parentClassName="mb-1"
+                  className="text-sm"
+                  theme="danger"
+                />
+              </>
+            )}
+          </h3>
+
+          <Input
+            type="text"
+            label={`Reference #${index + 1} Name`}
+            formData={{
+              id: `reference-name${index}`,
+              name: `reference-name${index}`,
+              value: ref.name
+            }}
+            handleChange={(e: React.ChangeEvent<HTMLInputElement>) => updateReference(index, 'name', e.target.value)}
+          />
+
+          <Input
+            type="text"
+            label={`Reference #${index + 1} Company`}
+            formData={{
+              id: `reference-company${index}`,
+              name: `reference-company${index}`,
+              value: ref.company
+            }}
+            handleChange={(e: React.ChangeEvent<HTMLInputElement>) => updateReference(index, 'company', e.target.value)}
+          />
+
+          <Input
+            type="text"
+            label={`Reference #${index + 1} Job Title (optional)`}
+            formData={{
+              id: `reference-title${index}`,
+              name: `reference-title${index}`,
+              value: ref.title
+            }}
+            handleChange={(e: React.ChangeEvent<HTMLInputElement>) => updateReference(index, 'title', e.target.value)}
+          />
+
+          <Input
+            type="text"
+            label={`Reference #${index + 1} Contact Phone (Optional if Email is provided)`}
+            formData={{
+              id: `reference-contact-phone${index}`,
+              name: `reference-contact-phone${index}`,
+              value: ref.contactPhone
+            }}
+            handleChange={(e: React.ChangeEvent<HTMLInputElement>) => updateReference(index, 'contactPhone', e.target.value)}
+          />
+
+          <Input
+            type="text"
+            label={`Reference #${index + 1} Contact Email (Optional if Phone is provided)`}
+            formData={{
+              id: `reference-contact-email${index}`,
+              name: `reference-contact-email${index}`,
+              value: ref.contactEmail
+            }}
+            handleChange={(e: React.ChangeEvent<HTMLInputElement>) => updateReference(index, 'contactEmail', e.target.value)}
+          />
+        </div>
+      ))}
+
+      <Button
+        text={references.length > 0 ? `Add Another Reference` : `Add Reference`}
+        theme="success"
+        className="text-sm"
+        onClick={addReference} />
+    </>
+  );
+}
+
+export default Reference;

--- a/test/lib/LaTeXService.test.ts
+++ b/test/lib/LaTeXService.test.ts
@@ -49,6 +49,7 @@ describe('LaTeXResumeGenerator', () => {
       }
     ],
     projects: [],
+    references: []
   };
 
   const mockSections: Section[] = [
@@ -402,6 +403,39 @@ describe('LaTeXResumeGenerator', () => {
       expect(result).toContain('\\item Test bullet 2');
     });
 
+    test('should format references section', () => {
+      const formData = {
+        ...mockFormData,
+        references: [
+          {
+            name: 'Jane Smith',
+            title: 'Manager',
+            company: 'Tech Corp',
+            contactEmail: 'jsmith@techcorp.com',
+            contactPhone: '555-123-4567'
+          }
+        ]
+      };
+
+      const result = latexGenerator.generateLaTeX(formData, [
+        {
+          id: 'references',
+          selected: true,
+          sortOrder: 0,
+          displayName: 'References',
+          href: '#references',
+          originalOrder: 0,
+          required: false,
+          sortable: false
+        }
+      ]);
+
+      expect(result).toContain('\\section*{References}');
+      expect(result).toContain('\\textbf{Jane Smith,} Tech Corp (Manager) \\\\');
+      expect(result).toContain('555-123-4567, jsmith@techcorp.com');
+
+    });
+
     test('should format generic section', () => {
       const mockFormData: FormData = {
         personalInfo: {
@@ -435,6 +469,7 @@ describe('LaTeXResumeGenerator', () => {
           }
         ],
         projects: [],
+        references: [],
         genericSections: {
           "genericSection0": {
             title: 'Custom Section',


### PR DESCRIPTION
[Demo](https://09f918e6.resumecorgi-8ai.pages.dev) (note, this will be deleted when this PR is closed).

Added new References section, that can be hidden and moved, like other sections:
![image](https://github.com/user-attachments/assets/be1aec79-7c5e-430d-9475-46d4262bfb3d)

In the editor, without any references:
![image](https://github.com/user-attachments/assets/8ddac5d1-4bbd-4a2f-b8ff-27fed61a5095)

Empty reference added: 
![image](https://github.com/user-attachments/assets/a206b532-7d7c-47b8-8b3e-34de5ec4dc72)

Preview with empty reference: 
![image](https://github.com/user-attachments/assets/f45bf4c6-cb7e-4a93-8970-e876b1390470)

Preview with reference with Company and Phone:
![image](https://github.com/user-attachments/assets/62e18748-0ce2-432e-a8cd-ef17f30793dd)

Preview with reference with Company and Email:
![image](https://github.com/user-attachments/assets/882efbb2-cf17-406f-94ff-936ce6e711d8)

Preview with reference with Company, Title, Phone and Email:
![image](https://github.com/user-attachments/assets/41c98a3d-ddeb-41bb-b400-a374c47e519c)

Preview with multiple references: 
![image](https://github.com/user-attachments/assets/23ecfd4a-2134-41f0-8eeb-901b2c0ac9b9)
