### PR TITLE
Resume Management: Add Ability to Work with Multiple Copies of Resumes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
+        "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.7",
         "@radix-ui/react-dropdown-menu": "^2.1.7",
         "@radix-ui/react-separator": "^1.1.3",
@@ -2129,6 +2130,120 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.2.tgz",
+      "integrity": "sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.3.tgz",
@@ -2632,6 +2747,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-escape-keydown": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
@@ -2654,6 +2787,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,11 @@
         "clsx": "^2.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.482.0",
+        "next-themes": "^0.4.6",
         "pdfjs-dist": "^5.1.91",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "sonner": "^2.0.6",
         "tailwind-merge": "^3.2.0",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -8132,6 +8134,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9080,6 +9092,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.6.tgz",
+      "integrity": "sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
     "clsx": "^2.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.482.0",
+    "next-themes": "^0.4.6",
     "pdfjs-dist": "^5.1.91",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "sonner": "^2.0.6",
     "tailwind-merge": "^3.2.0",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
+    "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.7",
     "@radix-ui/react-dropdown-menu": "^2.1.7",
     "@radix-ui/react-separator": "^1.1.3",

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -2,8 +2,8 @@ import React from "react";
 
 interface AlertProps {
   title: string;
-  description: string;
-  variant: "success" | "danger" | "info";
+  description: React.ReactNode;
+  variant: "success" | "danger" | "info" | "warning";
   additionalContent?: React.ReactNode
 }
 
@@ -12,6 +12,7 @@ export const Alert = ({title, description, variant = "success", additionalConten
     "success": "bg-lime-200 dark:bg-lime-700 border-lime-600 text-gray-900 dark:border-lime-500 dark:text-white dark:shadow-zinc-900",
     "danger": "bg-rose-200 dark:bg-rose-700 border-rose-600 text-gray-900 dark:border-rose-400 dark:text-white dark:shadow-zinc-900",
     "info": "bg-sky-200 dark:bg-blue-700 border-sky-600 text-gray-900 dark:border-blue-500 dark:text-white dark:shadow-zinc-900",
+    "warning": "bg-amber-200 dark:bg-amber-700 border-amber-600 text-gray-900 dark:border-amber-500 dark:text-white dark:shadow-zinc-900",
   }
 
   return (

--- a/src/components/AllResumesImporter.tsx
+++ b/src/components/AllResumesImporter.tsx
@@ -1,0 +1,100 @@
+import { importAllResumesFromJson } from "@/lib/ImportExportService";
+import React, { useState } from 'react';
+import { Input } from "./ui/input";
+import { Alert } from "./Alert";
+import Button from "./Button";
+import { DialogClose } from "./ui/dialog";
+
+interface AllResumesImporterProps {
+  onComplete: () => void;
+}
+
+export const AllResumesImporter = ({ onComplete }: AllResumesImporterProps) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [importResult, setImportResult] = useState<{ imported: number; skipped: number; renamed: number } | null>(null);
+  const [uploadComplete, setUploadComplete] = useState<boolean>(false);
+  
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    
+    setIsLoading(true);
+    setError(null);
+    
+    try {
+      const result = await importAllResumesFromJson(file);
+      setImportResult(result);
+      console.log('Resumes imported successfully', result);
+    } catch (err) {
+      setError((err as Error).message);
+      setImportResult(null);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleConfirm = () => {
+    onComplete();
+    setUploadComplete(true);
+  };
+  
+  return (
+    <>
+      <label htmlFor="allResumesJsonImport" className="text-sm">
+        <div className="ms-1 mb-1">All Resumes Export (.json)</div>
+        <Input 
+          id="allResumesJsonImport" 
+          type="file" 
+          accept=".json"
+          onChange={handleFileChange} 
+          disabled={isLoading || uploadComplete}
+        />
+      </label>
+      {isLoading && <div>Importing resumes...</div>}
+      {error && 
+        <>
+          <Alert title="Error" description={`Failed to import resumes: ${error}`} variant="danger" />
+        </>
+      }
+      {!isLoading && !uploadComplete && importResult && 
+        <>
+          <Alert 
+            title="Import Summary" 
+            description={
+              <>
+                <div>Successfully imported: {importResult.imported} resume{importResult.imported !== 1 ? 's' : ''}</div>
+                {importResult.renamed > 0 && (
+                  <div>Renamed due to conflicts: {importResult.renamed}</div>
+                )}
+                {importResult.skipped > 0 && (
+                  <div>Skipped due to errors: {importResult.skipped}</div>
+                )}
+              </>
+            } 
+            variant={importResult.skipped > 0 ? "warning" : "success"} 
+          />
+          <div className="pt-1">
+            <Button 
+              text="Done" 
+              theme="interaction" 
+              className="mb-0 text-sm"
+              onClick={handleConfirm} />
+          </div>
+        </>
+      }
+      {uploadComplete &&
+        <>
+          <DialogClose className="text-left">
+            <Alert title="Import Complete" description="You can now close this dialog." variant="success" />
+            <div className="mb-5"></div>
+            <Button 
+                text="Close" 
+                theme="interaction" 
+                className="mb-0 text-sm" />
+          </DialogClose>
+        </>
+      }
+    </>
+  );
+};

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import { useState } from "react";
 import { Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarTrigger } from "@/components/ui/sidebar"
 import SortableNav from "./SortableNav";
 import { DownloadCloud, ExternalLink, FileJson, FlaskConical, ListPlus, UploadCloud, ChevronDown } from "lucide-react";
 import Corgi from "./Corgi";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "./ui/dialog";
 import { ResumeImporter } from "./ResumeImporter";
+import { AllResumesImporter } from "./AllResumesImporter";
 import { FormData } from "@/types";
 import { TemplateSwitcher } from "./TemplateSwitcher";
 import { useResume } from '@/lib/ResumeContext';
@@ -36,6 +37,16 @@ function AppSidebar({
     }
   };
 
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [resumeManagerKey, setResumeManagerKey] = useState(0);
+  
+  const onImportAllComplete = () => {
+    setImportDialogOpen(false);
+
+    // Force ResumeManager to refresh by changing its key
+    setResumeManagerKey(prev => prev + 1);
+  };
+
   return (
     <Sidebar
       className="
@@ -60,7 +71,7 @@ function AppSidebar({
         <SidebarGroup>
           <SidebarGroupLabel className="text-gray-700 dark:text-zinc-300">Resume</SidebarGroupLabel>
           <SidebarGroupContent className="px-2">
-            <ResumeManager onNewResume={handleNewResume} />
+            <ResumeManager key={resumeManagerKey} onNewResume={handleNewResume} />
           </SidebarGroupContent>
         </SidebarGroup>
         <SidebarGroup className="block lg:hidden py-0">
@@ -117,39 +128,69 @@ function AppSidebar({
                     </DropdownMenuItem>
                     <DropdownMenuItem onClick={() => onExportAll?.()}>
                       <DownloadCloud className="mr-2 h-4 w-4" />
-                      All Resumes
+                      All Resumes as Collection
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
               </SidebarMenuItem>
-              <SidebarMenuItem key={"menu-import-resume"}>
-                <Dialog>
-                  <DialogTrigger asChild>
-                    <SidebarMenuButton asChild className="hover:bg-gray-200 dark:hover:bg-zinc-950/70">
-                      <a href={"#"}>
-                        <UploadCloud />
-                        <span>Import</span>
-                      </a>
+              <SidebarMenuItem key={"menu-import"}>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <SidebarMenuButton className="hover:bg-gray-200 dark:hover:bg-zinc-950/70 cursor-pointer">
+                      <UploadCloud />
+                      <span>Import</span>
+                      <ChevronDown className="ml-auto h-4 w-4" />
                     </SidebarMenuButton>
-                  </DialogTrigger>
-                  <DialogContent>
-                    <DialogHeader>
-                      <DialogTitle>
-                        <FileJson className="pb-1 inline me-1 size-6" strokeWidth={1.334} />
-                        Import Resume
-                      </DialogTitle>
-                      <DialogDescription>
-                        Import a file containing your resume content using the JSON Resume format.
-                        See
-                        <a href="https://jsonresume.org/schema" target="_blank" className="ms-1.5 me-0.5 text-purple-800 dark:text-purple-400 font-bold hover:underline">
-                          JSON Resume <ExternalLink className="inline size-4 pb-1" />
-                        </a> 
-                        for more details.
-                      </DialogDescription>
-                    </DialogHeader>
-                    <ResumeImporter onComplete={onImportJsonFormData} />
-                  </DialogContent>
-                </Dialog>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-60">
+                    <Dialog>
+                      <DialogTrigger asChild>
+                        <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                          <FileJson className="mr-2 h-4 w-4" />
+                          Single
+                        </DropdownMenuItem>
+                      </DialogTrigger>
+                      <DialogContent>
+                        <DialogHeader>
+                          <DialogTitle>
+                            <FileJson className="pb-1 inline me-1 size-6" strokeWidth={1.334} />
+                            Import Resume
+                          </DialogTitle>
+                          <DialogDescription>
+                            Import a file containing your resume content using the JSON Resume format.
+                            See
+                            <a href="https://jsonresume.org/schema" target="_blank" className="ms-1.5 me-0.5 text-purple-800 dark:text-purple-400 font-bold hover:underline">
+                              JSON Resume <ExternalLink className="inline size-4 pb-1" />
+                            </a> 
+                            for more details.
+                          </DialogDescription>
+                        </DialogHeader>
+                        <ResumeImporter onComplete={onImportJsonFormData} />
+                      </DialogContent>
+                    </Dialog>
+                    <Dialog open={importDialogOpen} onOpenChange={setImportDialogOpen}>
+                      <DialogTrigger asChild>
+                        <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                          <UploadCloud className="mr-2 h-4 w-4" />
+                          Collection
+                        </DropdownMenuItem>
+                      </DialogTrigger>
+                      <DialogContent>
+                        <DialogHeader>
+                          <DialogTitle>
+                            <UploadCloud className="pb-1 inline me-1 size-6" strokeWidth={1.334} />
+                            Import All Resumes
+                          </DialogTitle>
+                          <DialogDescription>
+                            Import a file containing multiple resumes exported using the "Export All" feature.
+                            Existing resumes with the same name will be kept and imported ones will be renamed.
+                          </DialogDescription>
+                        </DialogHeader>
+                        <AllResumesImporter onComplete={onImportAllComplete} />
+                      </DialogContent>
+                    </Dialog>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               </SidebarMenuItem>
               <SidebarMenuItem key={"menu-sample-resume"}>
                 <SidebarMenuButton asChild className="hover:bg-gray-200 dark:hover:bg-zinc-950/70">

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarTrigger } from "@/components/ui/sidebar"
 import SortableNav from "./SortableNav";
-import { DownloadCloud, EraserIcon, ExternalLink, FileJson, FlaskConical, ListPlus, UploadCloud } from "lucide-react";
+import { DownloadCloud, EraserIcon, ExternalLink, FileJson, FlaskConical, ListPlus, UploadCloud, Edit2, Check, X } from "lucide-react";
 import Corgi from "./Corgi";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "./ui/dialog";
 import { ResumeImporter } from "./ResumeImporter";
@@ -34,7 +34,49 @@ function AppSidebar({
   onExport,
   onImportJsonFormData,
 }: SidebarProps) {
-  const { addGenericSection } = useResume();
+  const { addGenericSection, resumeName, setResumeName } = useResume();
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [tempName, setTempName] = useState(resumeName);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setTempName(resumeName);
+  }, [resumeName]);
+
+  useEffect(() => {
+    if (isEditingName && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditingName]);
+
+  const handleStartEdit = () => {
+    setTempName(resumeName);
+    setIsEditingName(true);
+  };
+
+  const handleSaveEdit = () => {
+    const trimmedName = tempName.trim();
+    if (trimmedName && trimmedName !== resumeName) {
+      setResumeName(trimmedName);
+    }
+    setIsEditingName(false);
+  };
+
+  const handleCancelEdit = () => {
+    setTempName(resumeName);
+    setIsEditingName(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSaveEdit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      handleCancelEdit();
+    }
+  };
 
   return (
     <Sidebar
@@ -55,6 +97,51 @@ function AppSidebar({
         <SidebarGroup>
           <SidebarGroupContent>
             <TemplateSwitcher />
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel className="text-gray-700 dark:text-zinc-300">Resume Name</SidebarGroupLabel>
+          <SidebarGroupContent className="px-2">
+            {isEditingName ? (
+              <div className="flex items-center space-x-1">
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={tempName}
+                  onChange={(e) => setTempName(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  className="flex-1 px-2 py-1 text-sm bg-white dark:bg-zinc-700 border border-gray-300 dark:border-zinc-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  placeholder="Resume name"
+                />
+                <button
+                  onClick={handleSaveEdit}
+                  className="p-1 text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300"
+                  title="Save name"
+                >
+                  <Check className="size-4" />
+                </button>
+                <button
+                  onClick={handleCancelEdit}
+                  className="p-1 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                  title="Cancel edit"
+                >
+                  <X className="size-4" />
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center space-x-1 group">
+                <span className="flex-1 text-sm text-gray-700 dark:text-gray-300 font-medium truncate">
+                  {resumeName}
+                </span>
+                <button
+                  onClick={handleStartEdit}
+                  className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 opacity-0 group-hover:opacity-100 transition-opacity"
+                  title="Edit resume name"
+                >
+                  <Edit2 className="size-3" />
+                </button>
+              </div>
+            )}
           </SidebarGroupContent>
         </SidebarGroup>
         <SidebarGroup className="block lg:hidden py-0">

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarTrigger } from "@/components/ui/sidebar"
 import SortableNav from "./SortableNav";
-import { DownloadCloud, EraserIcon, ExternalLink, FileJson, FlaskConical, ListPlus, UploadCloud } from "lucide-react";
+import { DownloadCloud, ExternalLink, FileJson, FlaskConical, ListPlus, UploadCloud } from "lucide-react";
 import Corgi from "./Corgi";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "./ui/dialog";
 import { ResumeImporter } from "./ResumeImporter";
@@ -15,11 +15,6 @@ interface SidebarProps {
   sampleData?: () => void;
   onExport: () => void;
   onImportJsonFormData: (formData: FormData) => void;
-}
-
-const clearForm = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>, resetData?: () => void) => {
-  e.preventDefault();
-  resetData?.();
 }
 
 const exportJson = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>, onExport: () => void) => {
@@ -144,14 +139,6 @@ function AppSidebar({
                     <ResumeImporter onComplete={onImportJsonFormData} />
                   </DialogContent>
                 </Dialog>
-              </SidebarMenuItem>
-              <SidebarMenuItem key={"menu-clear-resume"}>
-                <SidebarMenuButton asChild className="hover:bg-gray-200 dark:hover:bg-zinc-950/70">
-                  <a href={"#"} onClick={(e) => clearForm(e, resetData)}>
-                    <EraserIcon />
-                    <span>Clear Form</span>
-                  </a>
-                </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem key={"menu-sample-resume"}>
                 <SidebarMenuButton asChild className="hover:bg-gray-200 dark:hover:bg-zinc-950/70">

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarTrigger } from "@/components/ui/sidebar"
 import SortableNav from "./SortableNav";
-import { DownloadCloud, ExternalLink, FileJson, FlaskConical, ListPlus, UploadCloud } from "lucide-react";
+import { DownloadCloud, ExternalLink, FileJson, FlaskConical, ListPlus, UploadCloud, ChevronDown } from "lucide-react";
 import Corgi from "./Corgi";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "./ui/dialog";
 import { ResumeImporter } from "./ResumeImporter";
@@ -9,17 +9,14 @@ import { FormData } from "@/types";
 import { TemplateSwitcher } from "./TemplateSwitcher";
 import { useResume } from '@/lib/ResumeContext';
 import ResumeManager from "./ResumeManager";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./ui/dropdown-menu";
 
 interface SidebarProps {
   resetData?: () => void;
   sampleData?: () => void;
   onExport: () => void;
+  onExportAll?: () => void;
   onImportJsonFormData: (formData: FormData) => void;
-}
-
-const exportJson = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>, onExport: () => void) => {
-  e.preventDefault();
-  onExport();
 }
 
 const corgiSize: number = 84;
@@ -28,6 +25,7 @@ function AppSidebar({
   resetData,
   sampleData,
   onExport,
+  onExportAll,
   onImportJsonFormData,
 }: SidebarProps) {
   const { addGenericSection } = useResume();
@@ -103,13 +101,26 @@ function AppSidebar({
           <SidebarGroupLabel>Data</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              <SidebarMenuItem key={"menu-export-resume"}>
-                <SidebarMenuButton asChild className="hover:bg-gray-200 dark:hover:bg-zinc-950/70">
-                  <a href={"#"} onClick={(e) => exportJson(e, onExport)}>
-                    <DownloadCloud />
-                    <span>Export</span>
-                  </a>
-                </SidebarMenuButton>
+              <SidebarMenuItem key={"menu-export"}>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <SidebarMenuButton className="hover:bg-gray-200 dark:hover:bg-zinc-950/70 cursor-pointer">
+                      <DownloadCloud />
+                      <span>Export</span>
+                      <ChevronDown className="ml-auto h-4 w-4" />
+                    </SidebarMenuButton>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-60">
+                    <DropdownMenuItem onClick={() => onExport()}>
+                      <FileJson className="mr-2 h-4 w-4" />
+                      Current Resume
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => onExportAll?.()}>
+                      <DownloadCloud className="mr-2 h-4 w-4" />
+                      All Resumes
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               </SidebarMenuItem>
               <SidebarMenuItem key={"menu-import-resume"}>
                 <Dialog>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -39,6 +39,36 @@ const exportJson = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>, onExport
 
 const corgiSize: number = 84;
 
+// Format relative time like "3 days ago", "2 weeks ago", etc.
+const formatRelativeTime = (dateString: string): string => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  
+  if (diffDays === 0) {
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    if (diffHours === 0) {
+      const diffMinutes = Math.floor(diffMs / (1000 * 60));
+      if (diffMinutes === 0) return 'just now';
+      if (diffMinutes === 1) return '1 minute ago';
+      return `${diffMinutes} minutes ago`;
+    }
+    if (diffHours === 1) return '1 hour ago';
+    return `${diffHours} hours ago`;
+  }
+  
+  if (diffDays === 1) return 'yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+  
+  const diffWeeks = Math.floor(diffDays / 7);
+  if (diffWeeks === 1) return '1 week ago';
+  if (diffWeeks < 4) return `${diffWeeks} weeks ago`;
+  
+  // More than a month, show the actual date
+  return date.toLocaleDateString();
+};
+
 function AppSidebar({
   resetData,
   sampleData,
@@ -205,27 +235,27 @@ function AppSidebar({
               </div>
             ) : (
               <div className="flex items-center space-x-1 group">
-                <span className="flex-1 text-sm text-gray-700 dark:text-gray-300 font-medium truncate">
+                <span className="flex-1 text-sm text-gray-700 dark:text-gray-300 font-bold truncate">
                   {resumeName}
                 </span>
                 <button
                   onClick={handleStartEdit}
-                  className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 opacity-0 group-hover:opacity-100 transition-opacity"
+                  className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
                   title="Edit resume name"
                 >
-                  <Edit2 className="size-3" />
+                  <Edit2 className="size-4" />
                 </button>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <button
-                      className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 opacity-0 group-hover:opacity-100 transition-opacity"
+                      className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
                       title="Resume options"
                     >
-                      <MoreVertical className="size-3" />
+                      <MoreVertical className="size-4" />
                     </button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="w-64">
-                    <DropdownMenuLabel>My Resumes</DropdownMenuLabel>
+                    <DropdownMenuLabel className="mb-0.75 text-xs">Resume</DropdownMenuLabel>
                     <DropdownMenuItem onClick={handleNewResume}>
                       <File className="mr-0.5 h-4 w-4" />
                       New
@@ -239,33 +269,23 @@ function AppSidebar({
                       Save As Copy
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
-                    <DropdownMenuLabel className="text-sm">Recent</DropdownMenuLabel>
+                    <DropdownMenuLabel className="mb-0.75 text-xs">Recent</DropdownMenuLabel>
                     {savedResumes.length > 0 ? (
                       <>
-                        {savedResumes.map((resume) => (
+                        {savedResumes.slice(0, 5).map((resume) => (
                           <div key={resume.id} className="group/item">
                             <DropdownMenuItem
                               onClick={() => handleLoadResume(resume.id)}
                               className="pr-8"
                             >
-                              <FileText className="mr-2 h-4 w-4" />
+                              <FileText className="mr-0.5" />
                               <div className="flex-1 overflow-hidden">
                                 <div className="truncate text-sm">{resume.name}</div>
                                 <div className="text-xs text-muted-foreground">
-                                  {new Date(resume.lastUpdated).toLocaleDateString()}
+                                  {formatRelativeTime(resume.lastUpdated)}
                                 </div>
                               </div>
                             </DropdownMenuItem>
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleDeleteResume(resume.id, resume.name);
-                              }}
-                              className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover/item:opacity-100 p-1 text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300"
-                              title="Delete resume"
-                            >
-                              <Trash2 className="size-3" />
-                            </button>
                           </div>
                         ))}
                       </>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,26 +1,14 @@
-import React, { useState, useRef, useEffect } from "react";
+import React from "react";
 import { Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarTrigger } from "@/components/ui/sidebar"
 import SortableNav from "./SortableNav";
-import { DownloadCloud, EraserIcon, ExternalLink, FileJson, FlaskConical, ListPlus, UploadCloud, Edit2, Check, X, MoreVertical, Copy, FileText, Trash2, SaveAllIcon, FolderOpen, Sheet, File } from "lucide-react";
+import { DownloadCloud, EraserIcon, ExternalLink, FileJson, FlaskConical, ListPlus, UploadCloud } from "lucide-react";
 import Corgi from "./Corgi";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "./ui/dialog";
 import { ResumeImporter } from "./ResumeImporter";
 import { FormData } from "@/types";
 import { TemplateSwitcher } from "./TemplateSwitcher";
 import { useResume } from '@/lib/ResumeContext';
-import Button from "./Button";
-import { 
-  DropdownMenu, 
-  DropdownMenuContent, 
-  DropdownMenuItem, 
-  DropdownMenuLabel, 
-  DropdownMenuSeparator, 
-  DropdownMenuTrigger 
-} from "./ui/dropdown-menu";
-import { Checkbox } from "./ui/checkbox";
-import { getSavedResumes, saveResumeCopy, loadResumeCopy, deleteResumeCopy } from '@/lib/StorageService';
-import { createSectionsFromFormData } from '@/lib/DataInitializer';
-import { toast } from "sonner";
+import ResumeManager from "./ResumeManager";
 
 interface SidebarProps {
   resetData?: () => void;
@@ -41,192 +29,17 @@ const exportJson = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>, onExport
 
 const corgiSize: number = 84;
 
-// Format relative time like "3 days ago", "2 weeks ago", etc.
-const formatRelativeTime = (dateString: string): string => {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  
-  if (diffDays === 0) {
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-    if (diffHours === 0) {
-      const diffMinutes = Math.floor(diffMs / (1000 * 60));
-      if (diffMinutes === 0) return 'just now';
-      if (diffMinutes === 1) return '1 minute ago';
-      return `${diffMinutes} minutes ago`;
-    }
-    if (diffHours === 1) return '1 hour ago';
-    return `${diffHours} hours ago`;
-  }
-  
-  if (diffDays === 1) return 'yesterday';
-  if (diffDays < 7) return `${diffDays} days ago`;
-  
-  const diffWeeks = Math.floor(diffDays / 7);
-  if (diffWeeks === 1) return '1 week ago';
-  if (diffWeeks < 4) return `${diffWeeks} weeks ago`;
-  
-  // More than a month, show the actual date
-  return date.toLocaleDateString();
-};
-
 function AppSidebar({
   resetData,
   sampleData,
   onExport,
   onImportJsonFormData,
 }: SidebarProps) {
-  const { formData, sections, addGenericSection, resumeName, setResumeName, setFormData, setSections, selectedTemplate } = useResume();
-  const [isEditingName, setIsEditingName] = useState(false);
-  const [tempName, setTempName] = useState(resumeName);
-  const [savedResumes, setSavedResumes] = useState(getSavedResumes());
-  const [isOpenDialogOpen, setIsOpenDialogOpen] = useState(false);
-  const [selectedResumeIds, setSelectedResumeIds] = useState<Set<string>>(new Set());
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    setTempName(resumeName);
-  }, [resumeName]);
-
-  useEffect(() => {
-    if (isEditingName && inputRef.current) {
-      inputRef.current.focus();
-      inputRef.current.select();
-    }
-  }, [isEditingName]);
-
-  const handleStartEdit = () => {
-    setTempName(resumeName);
-    setIsEditingName(true);
-  };
-
-  const handleSaveEdit = () => {
-    const trimmedName = tempName.trim();
-    if (trimmedName && trimmedName !== resumeName) {
-      setResumeName(trimmedName);
-    }
-    setIsEditingName(false);
-  };
-
-  const handleCancelEdit = () => {
-    setTempName(resumeName);
-    setIsEditingName(false);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      handleSaveEdit();
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      handleCancelEdit();
-    }
-  };
-
-  const handleSaveAsCopy = () => {
-    // Generate auto-incrementing name like "resume-name (1)", "resume-name (2)", etc.
-    const baseName = resumeName.replace(/ \(\d+\)$/, ''); // Remove existing (n) suffix if present
-    const existingResumes = getSavedResumes();
-    const existingNames = existingResumes.map(r => r.name);
-    
-    let copyNumber = 1;
-    let newName = `${baseName} (${copyNumber})`;
-    
-    // Find the next available number
-    while (existingNames.includes(newName)) {
-      copyNumber++;
-      newName = `${baseName} (${copyNumber})`;
-    }
-    
-    // Save the copy
-    const resumeId = saveResumeCopy({ formData, sections, templateId: selectedTemplate.id }, newName);
-    if (resumeId) {
-      // Immediately switch to the new copy
-      setResumeName(newName);
-      setSavedResumes(getSavedResumes());
-      toast.success(`Saved as copy: ${newName}`);
-    }
-  };
-
-  const handleLoadResume = (resumeId: string) => {
-    if (window.confirm('Loading this resume will replace your current work. Continue?')) {
-      const resumeData = loadResumeCopy(resumeId);
-      if (resumeData) {
-        setFormData(resumeData.formData);
-        setSections(resumeData.sections);
-        // Update the name from the saved copy
-        const savedCopy = savedResumes.find(r => r.id === resumeId);
-        if (savedCopy) {
-          setResumeName(savedCopy.name);
-        }
-        setIsOpenDialogOpen(false);
-      }
-    }
-  };
+  const { addGenericSection } = useResume();
 
   const handleNewResume = () => {
     if (window.confirm('Creating a new resume will clear your current work. Continue?')) {
       resetData?.();
-    }
-  };
-
-  const handleDeleteResume = (resumeId: string, resumeName: string) => {
-    if (window.confirm(`Are you sure you want to delete "${resumeName}"?`)) {
-      if (deleteResumeCopy(resumeId)) {
-        setSavedResumes(getSavedResumes());
-      }
-    }
-  };
-
-  // Refresh saved resumes when dialog opens and clear selections
-  useEffect(() => {
-    if (isOpenDialogOpen) {
-      setSavedResumes(getSavedResumes());
-      setSelectedResumeIds(new Set());
-    }
-  }, [isOpenDialogOpen]);
-
-  const handleDeleteSelected = () => {
-    const selectedCount = selectedResumeIds.size;
-    if (selectedCount === 0) return;
-    
-    const message = selectedCount === 1 
-      ? 'Are you sure you want to delete this resume?'
-      : `Are you sure you want to delete ${selectedCount} resumes?`;
-    
-    if (window.confirm(message)) {
-      let deletedCount = 0;
-      selectedResumeIds.forEach(id => {
-        if (deleteResumeCopy(id)) {
-          deletedCount++;
-        }
-      });
-      
-      setSavedResumes(getSavedResumes());
-      setSelectedResumeIds(new Set());
-      
-      if (deletedCount > 0) {
-        toast.success(`Deleted ${deletedCount} resume${deletedCount > 1 ? 's' : ''}`);
-      }
-    }
-  };
-
-  const toggleResumeSelection = (resumeId: string) => {
-    const newSelection = new Set(selectedResumeIds);
-    if (newSelection.has(resumeId)) {
-      newSelection.delete(resumeId);
-    } else {
-      newSelection.add(resumeId);
-    }
-    setSelectedResumeIds(newSelection);
-  };
-
-  const toggleSelectAll = () => {
-    if (selectedResumeIds.size === savedResumes.length) {
-      setSelectedResumeIds(new Set());
-    } else {
-      setSelectedResumeIds(new Set(savedResumes.map(r => r.id)));
     }
   };
 
@@ -254,97 +67,7 @@ function AppSidebar({
         <SidebarGroup>
           <SidebarGroupLabel className="text-gray-700 dark:text-zinc-300">Resume</SidebarGroupLabel>
           <SidebarGroupContent className="px-2">
-            {isEditingName ? (
-              <div className="flex items-center space-x-1">
-                <input
-                  ref={inputRef}
-                  type="text"
-                  value={tempName}
-                  onChange={(e) => setTempName(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="flex-1 px-2 py-1 text-sm bg-white dark:bg-zinc-700 border border-gray-300 dark:border-zinc-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-500"
-                  placeholder="Resume name"
-                />
-                <button
-                  onClick={handleSaveEdit}
-                  className="p-1 text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300"
-                  title="Save name"
-                >
-                  <Check className="size-4" />
-                </button>
-                <button
-                  onClick={handleCancelEdit}
-                  className="p-1 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                  title="Cancel edit"
-                >
-                  <X className="size-4" />
-                </button>
-              </div>
-            ) : (
-              <div className="flex items-center space-x-1 group">
-                <span className="flex-1 text-sm text-gray-700 dark:text-gray-300 font-bold truncate">
-                  {resumeName}
-                </span>
-                <button
-                  onClick={handleStartEdit}
-                  className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-                  title="Edit resume name"
-                >
-                  <Edit2 className="size-4" />
-                </button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-                      title="Resume options"
-                    >
-                      <MoreVertical className="size-4" />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-64">
-                    <DropdownMenuLabel className="mb-0.75 text-xs">Resume</DropdownMenuLabel>
-                    <DropdownMenuItem onClick={handleNewResume}>
-                      <File className="mr-0.5 h-4 w-4" />
-                      New
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => setIsOpenDialogOpen(true)}>
-                      <FolderOpen className="mr-0.5 h-4 w-4" />
-                      Open
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={handleSaveAsCopy}>
-                      <SaveAllIcon className="mr-0.5 h-4 w-4" />
-                      Save As Copy
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuLabel className="mb-0.75 text-xs">Recent</DropdownMenuLabel>
-                    {savedResumes.length > 0 ? (
-                      <>
-                        {savedResumes.slice(0, 5).map((resume) => (
-                          <div key={resume.id} className="group/item">
-                            <DropdownMenuItem
-                              onClick={() => handleLoadResume(resume.id)}
-                              className="pr-8"
-                            >
-                              <FileText className="mr-0.5" />
-                              <div className="flex-1 overflow-hidden">
-                                <div className="truncate text-sm">{resume.name}</div>
-                                <div className="text-xs text-muted-foreground">
-                                  {formatRelativeTime(resume.lastUpdated)}
-                                </div>
-                              </div>
-                            </DropdownMenuItem>
-                          </div>
-                        ))}
-                      </>
-                    ) : (
-                      <DropdownMenuItem disabled>
-                        <span className="text-muted-foreground">No recent resumes</span>
-                      </DropdownMenuItem>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            )}
+            <ResumeManager onNewResume={handleNewResume} />
           </SidebarGroupContent>
         </SidebarGroup>
         <SidebarGroup className="block lg:hidden py-0">
@@ -453,89 +176,6 @@ function AppSidebar({
             </div>
           </SidebarGroupContent>
         </SidebarGroup>
-        
-        {/* Open Resume Dialog */}
-        <Dialog open={isOpenDialogOpen} onOpenChange={setIsOpenDialogOpen}>
-          <DialogContent className="max-w-2xl max-h-[80vh]">
-            <DialogHeader>
-              <DialogTitle>
-                <FolderOpen className="pb-1 inline me-1 size-6" strokeWidth={1.334} />
-                Open Resume
-              </DialogTitle>
-              <DialogDescription>
-                Select a saved resume to open or manage your saved copies.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="space-y-4">
-              {savedResumes.length > 0 && (
-                <div className="flex items-center justify-between px-1">
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      checked={selectedResumeIds.size === savedResumes.length && savedResumes.length > 0}
-                      onCheckedChange={() => toggleSelectAll()}
-                    />
-                    <label className="text-sm font-medium">
-                      Select all ({savedResumes.length})
-                    </label>
-                  </div>
-                  {selectedResumeIds.size > 0 && (
-                    <Button
-                      theme="danger"
-                      text={`Delete (${selectedResumeIds.size})`}
-                      onClick={handleDeleteSelected}
-                      className="text-sm py-1.5"
-                    />
-                  )}
-                </div>
-              )}
-              <div className="overflow-y-auto max-h-[50vh]">
-                {savedResumes.length > 0 ? (
-                  <div className="space-y-2">
-                    {savedResumes.map((resume) => (
-                      <div
-                        key={resume.id}
-                        className={`group flex items-center justify-between p-3 border rounded-lg transition-colors ${
-                          selectedResumeIds.has(resume.id) 
-                            ? 'bg-blue-50 dark:bg-blue-950/30 border-blue-300 dark:border-blue-700' 
-                            : 'hover:bg-gray-50 dark:hover:bg-zinc-800'
-                        }`}
-                      >
-                        <div className="flex items-center space-x-3 flex-1 min-w-0">
-                          <Checkbox
-                            checked={selectedResumeIds.has(resume.id)}
-                            onCheckedChange={() => toggleResumeSelection(resume.id)}
-                            onClick={(e) => e.stopPropagation()}
-                          />
-                          <div 
-                            className="flex items-center space-x-3 flex-1 min-w-0 cursor-pointer"
-                            onClick={() => handleLoadResume(resume.id)}
-                          >
-                            <FileText className="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
-                            <div className="flex-1 min-w-0">
-                              <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                                {resume.name}
-                              </p>
-                              <p className="text-sm text-gray-500 dark:text-gray-400">
-                                Created: {new Date(resume.createdAt).toLocaleDateString()} • 
-                                Modified: {formatRelativeTime(resume.lastUpdated)}
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <div className="text-center py-8 text-gray-500 dark:text-gray-400">
-                    <FileText className="h-12 w-12 mx-auto mb-3 opacity-50" />
-                    <p>No saved resumes found</p>
-                    <p className="text-sm mt-1">Save your current resume using "Save As Copy" to get started</p>
-                  </div>
-                )}
-              </div>
-            </div>
-          </DialogContent>
-        </Dialog>
       </SidebarContent>
       <SidebarFooter className="text-center bg-gray-100/10 dark:bg-zinc-800/60">
         <div className="text-xs text-gray-600 dark:text-gray-400">

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -91,13 +91,29 @@ function AppSidebar({
   };
 
   const handleSaveAsCopy = () => {
-    const newName = prompt('Enter name for the resume copy:', `${resumeName}-copy`);
-    if (newName && newName.trim()) {
-      const resumeId = saveResumeCopy({ formData, sections, templateId: selectedTemplate.id }, newName.trim());
-      if (resumeId) {
-        setSavedResumes(getSavedResumes());
-        alert('Resume copy saved successfully!');
-      }
+    // Generate auto-incrementing name like "resume-name (1)", "resume-name (2)", etc.
+    const baseName = resumeName.replace(/ \(\d+\)$/, ''); // Remove existing (n) suffix if present
+    const existingResumes = getSavedResumes();
+    const existingNames = existingResumes.map(r => r.name);
+    
+    let copyNumber = 1;
+    let newName = `${baseName} (${copyNumber})`;
+    
+    // Find the next available number
+    while (existingNames.includes(newName)) {
+      copyNumber++;
+      newName = `${baseName} (${copyNumber})`;
+    }
+    
+    // Save the copy
+    const resumeId = saveResumeCopy({ formData, sections, templateId: selectedTemplate.id }, newName);
+    if (resumeId) {
+      // Immediately switch to the new copy
+      setResumeName(newName);
+      setSavedResumes(getSavedResumes());
+      
+      // Show a brief success message (optional - could use a toast instead)
+      console.log(`Saved as: ${newName}`);
     }
   };
 

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -48,6 +48,7 @@ function AppSidebar({
   const [isEditingName, setIsEditingName] = useState(false);
   const [tempName, setTempName] = useState(resumeName);
   const [savedResumes, setSavedResumes] = useState(getSavedResumes());
+  const [isOpenDialogOpen, setIsOpenDialogOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -111,7 +112,14 @@ function AppSidebar({
         if (savedCopy) {
           setResumeName(savedCopy.name);
         }
+        setIsOpenDialogOpen(false);
       }
+    }
+  };
+
+  const handleNewResume = () => {
+    if (window.confirm('Creating a new resume will clear your current work. Continue?')) {
+      resetData?.();
     }
   };
 
@@ -122,6 +130,13 @@ function AppSidebar({
       }
     }
   };
+
+  // Refresh saved resumes when dialog opens
+  useEffect(() => {
+    if (isOpenDialogOpen) {
+      setSavedResumes(getSavedResumes());
+    }
+  }, [isOpenDialogOpen]);
 
   return (
     <Sidebar
@@ -196,11 +211,11 @@ function AppSidebar({
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="w-64">
                     <DropdownMenuLabel>My Resumes</DropdownMenuLabel>
-                    <DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleNewResume}>
                       <File className="mr-0.5 h-4 w-4" />
                       New
                     </DropdownMenuItem>
-                    <DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => setIsOpenDialogOpen(true)}>
                       <FolderOpen className="mr-0.5 h-4 w-4" />
                       Open
                     </DropdownMenuItem>
@@ -356,6 +371,63 @@ function AppSidebar({
             </div>
           </SidebarGroupContent>
         </SidebarGroup>
+        
+        {/* Open Resume Dialog */}
+        <Dialog open={isOpenDialogOpen} onOpenChange={setIsOpenDialogOpen}>
+          <DialogContent className="max-w-2xl max-h-[80vh]">
+            <DialogHeader>
+              <DialogTitle>
+                <FolderOpen className="pb-1 inline me-1 size-6" strokeWidth={1.334} />
+                Open Resume
+              </DialogTitle>
+              <DialogDescription>
+                Select a saved resume to open. Your current work will be replaced.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="overflow-y-auto max-h-[50vh]">
+              {savedResumes.length > 0 ? (
+                <div className="space-y-2">
+                  {savedResumes.map((resume) => (
+                    <div
+                      key={resume.id}
+                      className="group flex items-center justify-between p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-800 cursor-pointer"
+                      onClick={() => handleLoadResume(resume.id)}
+                    >
+                      <div className="flex items-center space-x-3 flex-1 min-w-0">
+                        <FileText className="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                            {resume.name}
+                          </p>
+                          <p className="text-sm text-gray-500 dark:text-gray-400">
+                            Created: {new Date(resume.createdAt).toLocaleDateString()} • 
+                            Modified: {new Date(resume.lastUpdated).toLocaleDateString()}
+                          </p>
+                        </div>
+                      </div>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDeleteResume(resume.id, resume.name);
+                        }}
+                        className="ml-2 p-1.5 text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300 opacity-0 group-hover:opacity-100 transition-opacity"
+                        title="Delete resume"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+                  <FileText className="h-12 w-12 mx-auto mb-3 opacity-50" />
+                  <p>No saved resumes found</p>
+                  <p className="text-sm mt-1">Save your current resume using "Save As Copy" to get started</p>
+                </div>
+              )}
+            </div>
+          </DialogContent>
+        </Dialog>
       </SidebarContent>
       <SidebarFooter className="text-center bg-gray-100/10 dark:bg-zinc-800/60">
         <div className="text-xs text-gray-600 dark:text-gray-400">

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -18,6 +18,7 @@ import {
 } from "./ui/dropdown-menu";
 import { getSavedResumes, saveResumeCopy, loadResumeCopy, deleteResumeCopy } from '@/lib/StorageService';
 import { createSectionsFromFormData } from '@/lib/DataInitializer';
+import { toast } from "sonner";
 
 interface SidebarProps {
   resetData?: () => void;
@@ -111,9 +112,7 @@ function AppSidebar({
       // Immediately switch to the new copy
       setResumeName(newName);
       setSavedResumes(getSavedResumes());
-      
-      // Show a brief success message (optional - could use a toast instead)
-      console.log(`Saved as: ${newName}`);
+      toast.success(`Saved as copy: ${newName}`);
     }
   };
 
@@ -176,7 +175,7 @@ function AppSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
         <SidebarGroup>
-          <SidebarGroupLabel className="text-gray-700 dark:text-zinc-300">Resume Name</SidebarGroupLabel>
+          <SidebarGroupLabel className="text-gray-700 dark:text-zinc-300">Resume</SidebarGroupLabel>
           <SidebarGroupContent className="px-2">
             {isEditingName ? (
               <div className="flex items-center space-x-1">
@@ -240,7 +239,7 @@ function AppSidebar({
                       Save As Copy
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
-                    <DropdownMenuLabel className="text-sm">Recent Resumes</DropdownMenuLabel>
+                    <DropdownMenuLabel className="text-sm">Recent</DropdownMenuLabel>
                     {savedResumes.length > 0 ? (
                       <>
                         {savedResumes.map((resume) => (

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -8,6 +8,7 @@ import { ResumeImporter } from "./ResumeImporter";
 import { FormData } from "@/types";
 import { TemplateSwitcher } from "./TemplateSwitcher";
 import { useResume } from '@/lib/ResumeContext';
+import Button from "./Button";
 import { 
   DropdownMenu, 
   DropdownMenuContent, 
@@ -478,13 +479,12 @@ function AppSidebar({
                     </label>
                   </div>
                   {selectedResumeIds.size > 0 && (
-                    <button
+                    <Button
+                      theme="danger"
+                      text={`Delete (${selectedResumeIds.size})`}
                       onClick={handleDeleteSelected}
-                      className="flex items-center space-x-1 px-3 py-1.5 text-sm bg-red-500 hover:bg-red-600 text-white rounded-md transition-colors"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                      <span>Delete ({selectedResumeIds.size})</span>
-                    </button>
+                      className="text-sm py-1.5"
+                    />
                   )}
                 </div>
               )}

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,13 +1,23 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarTrigger } from "@/components/ui/sidebar"
 import SortableNav from "./SortableNav";
-import { DownloadCloud, EraserIcon, ExternalLink, FileJson, FlaskConical, ListPlus, UploadCloud, Edit2, Check, X } from "lucide-react";
+import { DownloadCloud, EraserIcon, ExternalLink, FileJson, FlaskConical, ListPlus, UploadCloud, Edit2, Check, X, MoreVertical, Copy, FileText, Trash2, SaveAllIcon, FolderOpen, Sheet, File } from "lucide-react";
 import Corgi from "./Corgi";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "./ui/dialog";
 import { ResumeImporter } from "./ResumeImporter";
 import { FormData } from "@/types";
 import { TemplateSwitcher } from "./TemplateSwitcher";
 import { useResume } from '@/lib/ResumeContext';
+import { 
+  DropdownMenu, 
+  DropdownMenuContent, 
+  DropdownMenuItem, 
+  DropdownMenuLabel, 
+  DropdownMenuSeparator, 
+  DropdownMenuTrigger 
+} from "./ui/dropdown-menu";
+import { getSavedResumes, saveResumeCopy, loadResumeCopy, deleteResumeCopy } from '@/lib/StorageService';
+import { createSectionsFromFormData } from '@/lib/DataInitializer';
 
 interface SidebarProps {
   resetData?: () => void;
@@ -34,9 +44,10 @@ function AppSidebar({
   onExport,
   onImportJsonFormData,
 }: SidebarProps) {
-  const { addGenericSection, resumeName, setResumeName } = useResume();
+  const { formData, sections, addGenericSection, resumeName, setResumeName, setFormData, setSections, selectedTemplate } = useResume();
   const [isEditingName, setIsEditingName] = useState(false);
   const [tempName, setTempName] = useState(resumeName);
+  const [savedResumes, setSavedResumes] = useState(getSavedResumes());
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -75,6 +86,40 @@ function AppSidebar({
     } else if (e.key === 'Escape') {
       e.preventDefault();
       handleCancelEdit();
+    }
+  };
+
+  const handleSaveAsCopy = () => {
+    const newName = prompt('Enter name for the resume copy:', `${resumeName}-copy`);
+    if (newName && newName.trim()) {
+      const resumeId = saveResumeCopy({ formData, sections, templateId: selectedTemplate.id }, newName.trim());
+      if (resumeId) {
+        setSavedResumes(getSavedResumes());
+        alert('Resume copy saved successfully!');
+      }
+    }
+  };
+
+  const handleLoadResume = (resumeId: string) => {
+    if (window.confirm('Loading this resume will replace your current work. Continue?')) {
+      const resumeData = loadResumeCopy(resumeId);
+      if (resumeData) {
+        setFormData(resumeData.formData);
+        setSections(resumeData.sections);
+        // Update the name from the saved copy
+        const savedCopy = savedResumes.find(r => r.id === resumeId);
+        if (savedCopy) {
+          setResumeName(savedCopy.name);
+        }
+      }
+    }
+  };
+
+  const handleDeleteResume = (resumeId: string, resumeName: string) => {
+    if (window.confirm(`Are you sure you want to delete "${resumeName}"?`)) {
+      if (deleteResumeCopy(resumeId)) {
+        setSavedResumes(getSavedResumes());
+      }
     }
   };
 
@@ -140,6 +185,67 @@ function AppSidebar({
                 >
                   <Edit2 className="size-3" />
                 </button>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 opacity-0 group-hover:opacity-100 transition-opacity"
+                      title="Resume options"
+                    >
+                      <MoreVertical className="size-3" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-64">
+                    <DropdownMenuLabel>My Resumes</DropdownMenuLabel>
+                    <DropdownMenuItem>
+                      <File className="mr-0.5 h-4 w-4" />
+                      New
+                    </DropdownMenuItem>
+                    <DropdownMenuItem>
+                      <FolderOpen className="mr-0.5 h-4 w-4" />
+                      Open
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleSaveAsCopy}>
+                      <SaveAllIcon className="mr-0.5 h-4 w-4" />
+                      Save As Copy
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuLabel className="text-sm">Recent Resumes</DropdownMenuLabel>
+                    {savedResumes.length > 0 ? (
+                      <>
+                        {savedResumes.map((resume) => (
+                          <div key={resume.id} className="group/item">
+                            <DropdownMenuItem
+                              onClick={() => handleLoadResume(resume.id)}
+                              className="pr-8"
+                            >
+                              <FileText className="mr-2 h-4 w-4" />
+                              <div className="flex-1 overflow-hidden">
+                                <div className="truncate text-sm">{resume.name}</div>
+                                <div className="text-xs text-muted-foreground">
+                                  {new Date(resume.lastUpdated).toLocaleDateString()}
+                                </div>
+                              </div>
+                            </DropdownMenuItem>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleDeleteResume(resume.id, resume.name);
+                              }}
+                              className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover/item:opacity-100 p-1 text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300"
+                              title="Delete resume"
+                            >
+                              <Trash2 className="size-3" />
+                            </button>
+                          </div>
+                        ))}
+                      </>
+                    ) : (
+                      <DropdownMenuItem disabled>
+                        <span className="text-muted-foreground">No recent resumes</span>
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
               </div>
             )}
           </SidebarGroupContent>

--- a/src/components/ResumeImporter.tsx
+++ b/src/components/ResumeImporter.tsx
@@ -14,7 +14,6 @@ export const ResumeImporter = ({ onComplete }: ResumeImporterProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<boolean>(false);
-  const [uploadedFormData, setUploadedFormData] = useState<FormData | null>(null);
   const [uploadComplete, setUploadComplete] = useState<boolean>(false);
   
   const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -26,8 +25,10 @@ export const ResumeImporter = ({ onComplete }: ResumeImporterProps) => {
     
     try {
       const formData = await importResumeFromJson(file);
-      setUploadedFormData(formData);
       console.log('Resume imported successfully', formData);
+      // Immediately complete the import without confirmation
+      onComplete(formData);
+      setUploadComplete(true);
       setSuccess(true);
     } catch (err) {
       setError((err as Error).message);
@@ -53,18 +54,6 @@ export const ResumeImporter = ({ onComplete }: ResumeImporterProps) => {
       {error && 
         <>
           <Alert title="Error" description="There was an issue uploading your resume content. Please ensure the content conforms to the JSON resume format and try again." variant="danger" />
-        </>
-      }
-      {!isLoading && !uploadComplete && success && 
-        <>
-          <Alert title="Confirm Upload" description="Your resume was successfully uploaded. Please confirm to overwrite your current edits with the uploaded resume content." variant="info" />
-          <div className="pt-1">
-            <Button 
-              text="Confirm Upload" 
-              theme="interaction" 
-              className="mb-0 text-sm"
-              onClick={() => { onComplete(uploadedFormData!); setUploadComplete(true); }} />
-          </div>
         </>
       }
       {uploadComplete &&

--- a/src/components/ResumeImporter.tsx
+++ b/src/components/ResumeImporter.tsx
@@ -13,7 +13,7 @@ interface ResumeImporterProps {
 export const ResumeImporter = ({ onComplete }: ResumeImporterProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<boolean>(false);
+  const [, setSuccess] = useState<boolean>(false);
   const [uploadComplete, setUploadComplete] = useState<boolean>(false);
   
   const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/ResumeManager.tsx
+++ b/src/components/ResumeManager.tsx
@@ -240,19 +240,19 @@ function ResumeManager({ onNewResume }: ResumeManagerProps) {
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-64">
               <DropdownMenuLabel className="mb-0.75 text-xs">Resume</DropdownMenuLabel>
-              <DropdownMenuItem onClick={onNewResume}>
+              <DropdownMenuItem className="text-xs" onClick={onNewResume}>
                 <File className="mr-0.5 h-4 w-4" />
                 New
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setIsOpenDialogOpen(true)}>
+              <DropdownMenuItem className="text-xs" onClick={() => setIsOpenDialogOpen(true)}>
                 <FolderOpen className="mr-0.5 h-4 w-4" />
                 Open
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={handleSaveAsCopy}>
+              <DropdownMenuItem className="text-xs" onClick={handleSaveAsCopy}>
                 <SaveAllIcon className="mr-0.5 h-4 w-4" />
                 Save As Copy
               </DropdownMenuItem>
-              <DropdownMenuSeparator />
+              <DropdownMenuSeparator className="bg-gray-300 dark:bg-zinc-800" />
               <DropdownMenuLabel className="mb-0.75 text-xs">Recent</DropdownMenuLabel>
               {savedResumes.length > 0 ? (
                 <>
@@ -260,12 +260,12 @@ function ResumeManager({ onNewResume }: ResumeManagerProps) {
                     <div key={resume.id} className="group/item">
                       <DropdownMenuItem
                         onClick={() => handleLoadResume(resume.id)}
-                        className="pr-8"
+                        className="text-xs pr-8"
                       >
                         <FileText className="mr-0.5" />
                         <div className="flex-1 overflow-hidden">
-                          <div className="truncate text-sm">{resume.name}</div>
-                          <div className="text-xs text-muted-foreground">
+                          <div className="truncate font-medium">{resume.name}</div>
+                          <div className="text-muted-foreground">
                             {formatRelativeTime(resume.lastUpdated)}
                           </div>
                         </div>
@@ -288,8 +288,8 @@ function ResumeManager({ onNewResume }: ResumeManagerProps) {
         <DialogContent className="max-w-2xl max-h-[80vh]">
           <DialogHeader>
             <DialogTitle>
-              <FolderOpen className="pb-1 inline me-1 size-6" strokeWidth={1.334} />
-              Open Resume
+              <FolderOpen className="pb-1 inline me-2 size-6" strokeWidth={1.334} />
+              Open
             </DialogTitle>
             <DialogDescription>
               Select a saved resume to open or manage your saved copies.
@@ -299,34 +299,35 @@ function ResumeManager({ onNewResume }: ResumeManagerProps) {
             {savedResumes.length > 0 && (
               <div className="flex items-center justify-between px-1">
                 <div className="flex items-center space-x-2">
-                  <Checkbox
-                    checked={selectedResumeIds.size === savedResumes.length && savedResumes.length > 0}
-                    onCheckedChange={() => toggleSelectAll()}
-                  />
                   <label className="text-sm font-medium">
-                    Select all ({savedResumes.length})
+                    <Checkbox
+                      checked={selectedResumeIds.size === savedResumes.length && savedResumes.length > 0}
+                      onCheckedChange={() => toggleSelectAll()}
+                    />
+                    <span className="ms-2">Select all ({savedResumes.length})</span>
                   </label>
                 </div>
-                {selectedResumeIds.size > 0 && (
-                  <Button
-                    theme="danger"
-                    text={`Delete (${selectedResumeIds.size})`}
-                    onClick={handleDeleteSelected}
-                    className="text-sm py-1.5"
-                  />
-                )}
+                <Button
+                  theme={`${selectedResumeIds.size === 0 ? 'default' : 'danger'}`}
+                  text={selectedResumeIds.size > 0 ? `Delete (${selectedResumeIds.size} selected)` : "Delete (None selected)"}
+                  onClick={handleDeleteSelected}
+                  className={`text-sm py-1.5`}
+                />
               </div>
             )}
-            <div className="overflow-y-auto max-h-[50vh]">
+            <div className="
+              overflow-y-auto max-h-[50vh] pr-1
+              [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-zinc-300 [&::-webkit-scrollbar-thumb]:bg-zinc-400 
+              dark:[&::-webkit-scrollbar-track]:bg-zinc-950/25 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-500/70">
               {savedResumes.length > 0 ? (
                 <div className="space-y-2">
                   {savedResumes.map((resume) => (
                     <div
                       key={resume.id}
-                      className={`group flex items-center justify-between p-3 border rounded-lg transition-colors ${
+                      className={`group flex items-center justify-between py-2 px-3 border rounded-lg ${
                         selectedResumeIds.has(resume.id) 
-                          ? 'bg-blue-50 dark:bg-blue-950/30 border-blue-300 dark:border-blue-700' 
-                          : 'hover:bg-gray-50 dark:hover:bg-zinc-800'
+                          ? 'bg-purple-50 dark:bg-purple-950/30 border-purple-300 dark:border-purple-700' 
+                          : 'border-gray-300 dark:border-zinc-800 hover:bg-gray-100 dark:hover:bg-zinc-800'
                       }`}
                     >
                       <div className="flex items-center space-x-3 flex-1 min-w-0">
@@ -339,14 +340,13 @@ function ResumeManager({ onNewResume }: ResumeManagerProps) {
                           className="flex items-center space-x-3 flex-1 min-w-0 cursor-pointer"
                           onClick={() => handleLoadResume(resume.id)}
                         >
-                          <FileText className="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
+                          <FileText className="font-thin h-6 w-6 text-gray-700 dark:text-gray-300 flex-shrink-0" strokeWidth={1.5} />
                           <div className="flex-1 min-w-0">
                             <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
                               {resume.name}
                             </p>
-                            <p className="text-sm text-gray-500 dark:text-gray-400">
-                              Created: {new Date(resume.createdAt).toLocaleDateString()} • 
-                              Modified: {formatRelativeTime(resume.lastUpdated)}
+                            <p className="text-xs text-gray-500 dark:text-gray-400">
+                              Modified {formatRelativeTime(resume.lastUpdated)}
                             </p>
                           </div>
                         </div>

--- a/src/components/ResumeManager.tsx
+++ b/src/components/ResumeManager.tsx
@@ -1,0 +1,372 @@
+import React, { useState, useRef, useEffect } from "react";
+import { Edit2, Check, X, MoreVertical, FileText, SaveAllIcon, FolderOpen, File } from "lucide-react";
+import { 
+  DropdownMenu, 
+  DropdownMenuContent, 
+  DropdownMenuItem, 
+  DropdownMenuLabel, 
+  DropdownMenuSeparator, 
+  DropdownMenuTrigger 
+} from "./ui/dropdown-menu";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./ui/dialog";
+import { Checkbox } from "./ui/checkbox";
+import Button from "./Button";
+import { getSavedResumes, saveResumeCopy, loadResumeCopy, deleteResumeCopy } from '@/lib/StorageService';
+import { useResume } from '@/lib/ResumeContext';
+import { toast } from "sonner";
+
+interface ResumeManagerProps {
+  onNewResume: () => void;
+}
+
+// Format relative time like "3 days ago", "2 weeks ago", etc.
+const formatRelativeTime = (dateString: string): string => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  
+  if (diffDays === 0) {
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    if (diffHours === 0) {
+      const diffMinutes = Math.floor(diffMs / (1000 * 60));
+      if (diffMinutes === 0) return 'just now';
+      if (diffMinutes === 1) return '1 minute ago';
+      return `${diffMinutes} minutes ago`;
+    }
+    if (diffHours === 1) return '1 hour ago';
+    return `${diffHours} hours ago`;
+  }
+  
+  if (diffDays === 1) return 'yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+  
+  const diffWeeks = Math.floor(diffDays / 7);
+  if (diffWeeks === 1) return '1 week ago';
+  if (diffWeeks < 4) return `${diffWeeks} weeks ago`;
+  
+  // More than a month, show the actual date
+  return date.toLocaleDateString();
+};
+
+function ResumeManager({ onNewResume }: ResumeManagerProps) {
+  const { formData, sections, resumeName, setResumeName, setFormData, setSections, selectedTemplate } = useResume();
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [tempName, setTempName] = useState(resumeName);
+  const [savedResumes, setSavedResumes] = useState(getSavedResumes());
+  const [isOpenDialogOpen, setIsOpenDialogOpen] = useState(false);
+  const [selectedResumeIds, setSelectedResumeIds] = useState<Set<string>>(new Set());
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setTempName(resumeName);
+  }, [resumeName]);
+
+  useEffect(() => {
+    if (isEditingName && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditingName]);
+
+  // Refresh saved resumes when dialog opens and clear selections
+  useEffect(() => {
+    if (isOpenDialogOpen) {
+      setSavedResumes(getSavedResumes());
+      setSelectedResumeIds(new Set());
+    }
+  }, [isOpenDialogOpen]);
+
+  const handleStartEdit = () => {
+    setTempName(resumeName);
+    setIsEditingName(true);
+  };
+
+  const handleSaveEdit = () => {
+    const trimmedName = tempName.trim();
+    if (trimmedName && trimmedName !== resumeName) {
+      setResumeName(trimmedName);
+    }
+    setIsEditingName(false);
+  };
+
+  const handleCancelEdit = () => {
+    setTempName(resumeName);
+    setIsEditingName(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSaveEdit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      handleCancelEdit();
+    }
+  };
+
+  const handleSaveAsCopy = () => {
+    // Generate auto-incrementing name like "resume-name (1)", "resume-name (2)", etc.
+    const baseName = resumeName.replace(/ \(\d+\)$/, ''); // Remove existing (n) suffix if present
+    const existingResumes = getSavedResumes();
+    const existingNames = existingResumes.map(r => r.name);
+    
+    let copyNumber = 1;
+    let newName = `${baseName} (${copyNumber})`;
+    
+    // Find the next available number
+    while (existingNames.includes(newName)) {
+      copyNumber++;
+      newName = `${baseName} (${copyNumber})`;
+    }
+    
+    // Save the copy
+    const resumeId = saveResumeCopy({ formData, sections, templateId: selectedTemplate.id }, newName);
+    if (resumeId) {
+      // Immediately switch to the new copy
+      setResumeName(newName);
+      setSavedResumes(getSavedResumes());
+      toast.success(`Saved as copy: ${newName}`);
+    }
+  };
+
+  const handleLoadResume = (resumeId: string) => {
+    if (window.confirm('Loading this resume will replace your current work. Continue?')) {
+      const resumeData = loadResumeCopy(resumeId);
+      if (resumeData) {
+        setFormData(resumeData.formData);
+        setSections(resumeData.sections);
+        // Update the name from the saved copy
+        const savedCopy = savedResumes.find(r => r.id === resumeId);
+        if (savedCopy) {
+          setResumeName(savedCopy.name);
+        }
+        setIsOpenDialogOpen(false);
+      }
+    }
+  };
+
+  const handleDeleteSelected = () => {
+    const selectedCount = selectedResumeIds.size;
+    if (selectedCount === 0) return;
+    
+    const message = selectedCount === 1 
+      ? 'Are you sure you want to delete this resume?'
+      : `Are you sure you want to delete ${selectedCount} resumes?`;
+    
+    if (window.confirm(message)) {
+      let deletedCount = 0;
+      selectedResumeIds.forEach(id => {
+        if (deleteResumeCopy(id)) {
+          deletedCount++;
+        }
+      });
+      
+      setSavedResumes(getSavedResumes());
+      setSelectedResumeIds(new Set());
+      
+      if (deletedCount > 0) {
+        toast.success(`Deleted ${deletedCount} resume${deletedCount > 1 ? 's' : ''}`);
+      }
+    }
+  };
+
+  const toggleResumeSelection = (resumeId: string) => {
+    const newSelection = new Set(selectedResumeIds);
+    if (newSelection.has(resumeId)) {
+      newSelection.delete(resumeId);
+    } else {
+      newSelection.add(resumeId);
+    }
+    setSelectedResumeIds(newSelection);
+  };
+
+  const toggleSelectAll = () => {
+    if (selectedResumeIds.size === savedResumes.length) {
+      setSelectedResumeIds(new Set());
+    } else {
+      setSelectedResumeIds(new Set(savedResumes.map(r => r.id)));
+    }
+  };
+
+  return (
+    <>
+      {isEditingName ? (
+        <div className="flex items-center space-x-1">
+          <input
+            ref={inputRef}
+            type="text"
+            value={tempName}
+            onChange={(e) => setTempName(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="flex-1 px-2 py-1 text-sm bg-white dark:bg-zinc-700 border border-gray-300 dark:border-zinc-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-500"
+            placeholder="Resume name"
+          />
+          <button
+            onClick={handleSaveEdit}
+            className="p-1 text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300"
+            title="Save name"
+          >
+            <Check className="size-4" />
+          </button>
+          <button
+            onClick={handleCancelEdit}
+            className="p-1 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+            title="Cancel edit"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center space-x-1 group">
+          <span className="flex-1 text-sm text-gray-700 dark:text-gray-300 font-bold truncate">
+            {resumeName}
+          </span>
+          <button
+            onClick={handleStartEdit}
+            className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            title="Edit resume name"
+          >
+            <Edit2 className="size-4" />
+          </button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                title="Resume options"
+              >
+                <MoreVertical className="size-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-64">
+              <DropdownMenuLabel className="mb-0.75 text-xs">Resume</DropdownMenuLabel>
+              <DropdownMenuItem onClick={onNewResume}>
+                <File className="mr-0.5 h-4 w-4" />
+                New
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setIsOpenDialogOpen(true)}>
+                <FolderOpen className="mr-0.5 h-4 w-4" />
+                Open
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleSaveAsCopy}>
+                <SaveAllIcon className="mr-0.5 h-4 w-4" />
+                Save As Copy
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="mb-0.75 text-xs">Recent</DropdownMenuLabel>
+              {savedResumes.length > 0 ? (
+                <>
+                  {savedResumes.slice(0, 5).map((resume) => (
+                    <div key={resume.id} className="group/item">
+                      <DropdownMenuItem
+                        onClick={() => handleLoadResume(resume.id)}
+                        className="pr-8"
+                      >
+                        <FileText className="mr-0.5" />
+                        <div className="flex-1 overflow-hidden">
+                          <div className="truncate text-sm">{resume.name}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {formatRelativeTime(resume.lastUpdated)}
+                          </div>
+                        </div>
+                      </DropdownMenuItem>
+                    </div>
+                  ))}
+                </>
+              ) : (
+                <DropdownMenuItem disabled>
+                  <span className="text-muted-foreground">No recent resumes</span>
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
+
+      {/* Open Resume Dialog */}
+      <Dialog open={isOpenDialogOpen} onOpenChange={setIsOpenDialogOpen}>
+        <DialogContent className="max-w-2xl max-h-[80vh]">
+          <DialogHeader>
+            <DialogTitle>
+              <FolderOpen className="pb-1 inline me-1 size-6" strokeWidth={1.334} />
+              Open Resume
+            </DialogTitle>
+            <DialogDescription>
+              Select a saved resume to open or manage your saved copies.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            {savedResumes.length > 0 && (
+              <div className="flex items-center justify-between px-1">
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    checked={selectedResumeIds.size === savedResumes.length && savedResumes.length > 0}
+                    onCheckedChange={() => toggleSelectAll()}
+                  />
+                  <label className="text-sm font-medium">
+                    Select all ({savedResumes.length})
+                  </label>
+                </div>
+                {selectedResumeIds.size > 0 && (
+                  <Button
+                    theme="danger"
+                    text={`Delete (${selectedResumeIds.size})`}
+                    onClick={handleDeleteSelected}
+                    className="text-sm py-1.5"
+                  />
+                )}
+              </div>
+            )}
+            <div className="overflow-y-auto max-h-[50vh]">
+              {savedResumes.length > 0 ? (
+                <div className="space-y-2">
+                  {savedResumes.map((resume) => (
+                    <div
+                      key={resume.id}
+                      className={`group flex items-center justify-between p-3 border rounded-lg transition-colors ${
+                        selectedResumeIds.has(resume.id) 
+                          ? 'bg-blue-50 dark:bg-blue-950/30 border-blue-300 dark:border-blue-700' 
+                          : 'hover:bg-gray-50 dark:hover:bg-zinc-800'
+                      }`}
+                    >
+                      <div className="flex items-center space-x-3 flex-1 min-w-0">
+                        <Checkbox
+                          checked={selectedResumeIds.has(resume.id)}
+                          onCheckedChange={() => toggleResumeSelection(resume.id)}
+                          onClick={(e) => e.stopPropagation()}
+                        />
+                        <div 
+                          className="flex items-center space-x-3 flex-1 min-w-0 cursor-pointer"
+                          onClick={() => handleLoadResume(resume.id)}
+                        >
+                          <FileText className="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                              {resume.name}
+                            </p>
+                            <p className="text-sm text-gray-500 dark:text-gray-400">
+                              Created: {new Date(resume.createdAt).toLocaleDateString()} • 
+                              Modified: {formatRelativeTime(resume.lastUpdated)}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+                  <FileText className="h-12 w-12 mx-auto mb-3 opacity-50" />
+                  <p>No saved resumes found</p>
+                  <p className="text-sm mt-1">Save your current resume using "Save As Copy" to get started</p>
+                </div>
+              )}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+export default ResumeManager;

--- a/src/components/ResumeManager.tsx
+++ b/src/components/ResumeManager.tsx
@@ -147,29 +147,27 @@ function ResumeManager({ onNewResume }: ResumeManagerProps) {
   };
 
   const handleLoadResume = (resumeId: string) => {
-    if (window.confirm('Loading this resume will replace your current work. Continue?')) {
-      const resumeData = loadResumeCopy(resumeId);
-      if (resumeData) {
-        setFormData(resumeData.formData);
-        setSections(resumeData.sections);
-        
-        // Update the template if it's stored
-        if (resumeData.templateId) {
-          const template = TemplateFactory.getAvailableTemplates().find(t => t.id === resumeData.templateId);
-          if (template) {
-            setSelectedTemplate(template);
-          }
+    const resumeData = loadResumeCopy(resumeId);
+    if (resumeData) {
+      setFormData(resumeData.formData);
+      setSections(resumeData.sections);
+      
+      // Update the template if it's stored
+      if (resumeData.templateId) {
+        const template = TemplateFactory.getAvailableTemplates().find(t => t.id === resumeData.templateId);
+        if (template) {
+          setSelectedTemplate(template);
         }
-        
-        // Update the name from the saved copy
-        const savedCopy = savedResumes.find(r => r.id === resumeId);
-        if (savedCopy) {
-          setResumeName(savedCopy.name);
-        }
-        // Set the currentResumeId to track which resume is loaded
-        setCurrentResumeId(resumeId);
-        setIsOpenDialogOpen(false);
       }
+      
+      // Update the name from the saved copy
+      const savedCopy = savedResumes.find(r => r.id === resumeId);
+      if (savedCopy) {
+        setResumeName(savedCopy.name);
+      }
+      // Set the currentResumeId to track which resume is loaded
+      setCurrentResumeId(resumeId);
+      setIsOpenDialogOpen(false);
     }
   };
 

--- a/src/components/ResumeManager.tsx
+++ b/src/components/ResumeManager.tsx
@@ -13,6 +13,7 @@ import { Checkbox } from "./ui/checkbox";
 import Button from "./Button";
 import { getSavedResumes, loadResumeCopy, deleteResumeCopy, renameResumeCopy, updateOrCreateResumeCopy } from '@/lib/StorageService';
 import { useResume } from '@/lib/ResumeContext';
+import { TemplateFactory } from '@/lib/LaTeX/TemplateFactory';
 import { toast } from "sonner";
 
 interface ResumeManagerProps {
@@ -50,7 +51,7 @@ const formatRelativeTime = (dateString: string): string => {
 };
 
 function ResumeManager({ onNewResume }: ResumeManagerProps) {
-  const { formData, sections, resumeName, setResumeName, setFormData, setSections, selectedTemplate, currentResumeId, setCurrentResumeId } = useResume();
+  const { formData, sections, resumeName, setResumeName, setFormData, setSections, selectedTemplate, currentResumeId, setCurrentResumeId, setSelectedTemplate } = useResume();
   const [isEditingName, setIsEditingName] = useState(false);
   const [tempName, setTempName] = useState(resumeName);
   const [savedResumes, setSavedResumes] = useState(getSavedResumes());
@@ -151,6 +152,15 @@ function ResumeManager({ onNewResume }: ResumeManagerProps) {
       if (resumeData) {
         setFormData(resumeData.formData);
         setSections(resumeData.sections);
+        
+        // Update the template if it's stored
+        if (resumeData.templateId) {
+          const template = TemplateFactory.getAvailableTemplates().find(t => t.id === resumeData.templateId);
+          if (template) {
+            setSelectedTemplate(template);
+          }
+        }
+        
         // Update the name from the saved copy
         const savedCopy = savedResumes.find(r => r.id === resumeId);
         if (savedCopy) {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,21 +1,69 @@
-import { CloudDownload, CodeSquare, } from "lucide-react";
+import { CloudDownload, CodeSquare, Edit2, Check, X } from "lucide-react";
 import StatusIndicator from "./StatusIndicator";
+import { useState, useRef, useEffect } from "react";
 
 interface ToolbarProps {
   error: string | null;
   isLoading?: boolean;
   pageRendered?: boolean;
+  resumeName: string;
   onDownloadPdf: () => void;
   onDownloadLaTeX: () => void;
+  onResumeNameChange: (name: string) => void;
 }
 
 function Toolbar({
   error,
   isLoading,
   pageRendered,
+  resumeName,
   onDownloadPdf,
-  onDownloadLaTeX
+  onDownloadLaTeX,
+  onResumeNameChange
 }: ToolbarProps) {
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [tempName, setTempName] = useState(resumeName);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setTempName(resumeName);
+  }, [resumeName]);
+
+  useEffect(() => {
+    if (isEditingName && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditingName]);
+
+  const handleStartEdit = () => {
+    setTempName(resumeName);
+    setIsEditingName(true);
+  };
+
+  const handleSaveEdit = () => {
+    const trimmedName = tempName.trim();
+    if (trimmedName && trimmedName !== resumeName) {
+      onResumeNameChange(trimmedName);
+    }
+    setIsEditingName(false);
+  };
+
+  const handleCancelEdit = () => {
+    setTempName(resumeName);
+    setIsEditingName(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSaveEdit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      handleCancelEdit();
+    }
+  };
+
   const buttonCss =
     `transition-colors
     px-2 py-1.5
@@ -38,8 +86,52 @@ function Toolbar({
 
         {/* Desktop layout - all in one row */}
         <div className="hidden lg:flex lg:flex-row lg:justify-between rounded-lg max-w-[800px] mx-auto px-4 md:px-0" role="group">
-          <div className="flex-1 inline-flex items-center">
+          <div className="flex-1 inline-flex items-center space-x-3">
             <StatusIndicator error={error} isLoading={isLoading} pageRendered={pageRendered} />
+            
+            {/* Resume name editor */}
+            <div className="flex items-center">
+              {isEditingName ? (
+                <div className="flex items-center space-x-1">
+                  <input
+                    ref={inputRef}
+                    type="text"
+                    value={tempName}
+                    onChange={(e) => setTempName(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    className="px-2 py-1 text-sm bg-white dark:bg-zinc-700 border border-gray-300 dark:border-zinc-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-500 min-w-[200px]"
+                    placeholder="Resume name"
+                  />
+                  <button
+                    onClick={handleSaveEdit}
+                    className="p-1 text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300"
+                    title="Save name"
+                  >
+                    <Check className="size-4" />
+                  </button>
+                  <button
+                    onClick={handleCancelEdit}
+                    className="p-1 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                    title="Cancel edit"
+                  >
+                    <X className="size-4" />
+                  </button>
+                </div>
+              ) : (
+                <div className="flex items-center space-x-1 group">
+                  <span className="text-sm text-gray-700 dark:text-gray-300 font-medium">
+                    {resumeName}
+                  </span>
+                  <button
+                    onClick={handleStartEdit}
+                    className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 opacity-0 group-hover:opacity-100 transition-opacity"
+                    title="Edit resume name"
+                  >
+                    <Edit2 className="size-3" />
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
 
           <div className="flex-1 flex justify-end">
@@ -68,15 +160,59 @@ function Toolbar({
           </div>
         </div>
 
-        {/* Mobile layout - two rows */}
+        {/* Mobile layout - three rows */}
         <div className="flex flex-col lg:hidden rounded-lg px-4" role="group">
           {/* First row - status indicator only */}
-          <div className="inline-flex items-center justify-center mb-0">
+          <div className="inline-flex items-center justify-center mb-2">
             <StatusIndicator error={error} isLoading={isLoading} pageRendered={pageRendered} />
           </div>
 
-          {/* Second row - buttons right */}
-          <div className="flex flex-row justify-between items-center">
+          {/* Second row - resume name editor */}
+          <div className="flex items-center justify-center mb-2">
+            {isEditingName ? (
+              <div className="flex items-center space-x-1">
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={tempName}
+                  onChange={(e) => setTempName(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  className="px-2 py-1 text-sm bg-white dark:bg-zinc-700 border border-gray-300 dark:border-zinc-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-500 min-w-[200px]"
+                  placeholder="Resume name"
+                />
+                <button
+                  onClick={handleSaveEdit}
+                  className="p-1 text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300"
+                  title="Save name"
+                >
+                  <Check className="size-4" />
+                </button>
+                <button
+                  onClick={handleCancelEdit}
+                  className="p-1 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                  title="Cancel edit"
+                >
+                  <X className="size-4" />
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center space-x-1 group">
+                <span className="text-sm text-gray-700 dark:text-gray-300 font-medium">
+                  {resumeName}
+                </span>
+                <button
+                  onClick={handleStartEdit}
+                  className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                  title="Edit resume name"
+                >
+                  <Edit2 className="size-3" />
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Third row - buttons */}
+          <div className="flex flex-row justify-center items-center">
 
             <div className="inline-flex">
               <button type="button"

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,68 +1,21 @@
-import { CloudDownload, CodeSquare, Edit2, Check, X } from "lucide-react";
+import { CloudDownload, CodeSquare, } from "lucide-react";
 import StatusIndicator from "./StatusIndicator";
-import { useState, useRef, useEffect } from "react";
 
 interface ToolbarProps {
   error: string | null;
   isLoading?: boolean;
   pageRendered?: boolean;
-  resumeName: string;
   onDownloadPdf: () => void;
   onDownloadLaTeX: () => void;
-  onResumeNameChange: (name: string) => void;
 }
 
 function Toolbar({
   error,
   isLoading,
   pageRendered,
-  resumeName,
   onDownloadPdf,
-  onDownloadLaTeX,
-  onResumeNameChange
+  onDownloadLaTeX
 }: ToolbarProps) {
-  const [isEditingName, setIsEditingName] = useState(false);
-  const [tempName, setTempName] = useState(resumeName);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    setTempName(resumeName);
-  }, [resumeName]);
-
-  useEffect(() => {
-    if (isEditingName && inputRef.current) {
-      inputRef.current.focus();
-      inputRef.current.select();
-    }
-  }, [isEditingName]);
-
-  const handleStartEdit = () => {
-    setTempName(resumeName);
-    setIsEditingName(true);
-  };
-
-  const handleSaveEdit = () => {
-    const trimmedName = tempName.trim();
-    if (trimmedName && trimmedName !== resumeName) {
-      onResumeNameChange(trimmedName);
-    }
-    setIsEditingName(false);
-  };
-
-  const handleCancelEdit = () => {
-    setTempName(resumeName);
-    setIsEditingName(false);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      handleSaveEdit();
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      handleCancelEdit();
-    }
-  };
 
   const buttonCss =
     `transition-colors
@@ -86,52 +39,8 @@ function Toolbar({
 
         {/* Desktop layout - all in one row */}
         <div className="hidden lg:flex lg:flex-row lg:justify-between rounded-lg max-w-[800px] mx-auto px-4 md:px-0" role="group">
-          <div className="flex-1 inline-flex items-center space-x-3">
+          <div className="flex-1 inline-flex items-center">
             <StatusIndicator error={error} isLoading={isLoading} pageRendered={pageRendered} />
-            
-            {/* Resume name editor */}
-            <div className="flex items-center">
-              {isEditingName ? (
-                <div className="flex items-center space-x-1">
-                  <input
-                    ref={inputRef}
-                    type="text"
-                    value={tempName}
-                    onChange={(e) => setTempName(e.target.value)}
-                    onKeyDown={handleKeyDown}
-                    className="px-2 py-1 text-sm bg-white dark:bg-zinc-700 border border-gray-300 dark:border-zinc-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-500 min-w-[200px]"
-                    placeholder="Resume name"
-                  />
-                  <button
-                    onClick={handleSaveEdit}
-                    className="p-1 text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300"
-                    title="Save name"
-                  >
-                    <Check className="size-4" />
-                  </button>
-                  <button
-                    onClick={handleCancelEdit}
-                    className="p-1 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                    title="Cancel edit"
-                  >
-                    <X className="size-4" />
-                  </button>
-                </div>
-              ) : (
-                <div className="flex items-center space-x-1 group">
-                  <span className="text-sm text-gray-700 dark:text-gray-300 font-medium">
-                    {resumeName}
-                  </span>
-                  <button
-                    onClick={handleStartEdit}
-                    className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 opacity-0 group-hover:opacity-100 transition-opacity"
-                    title="Edit resume name"
-                  >
-                    <Edit2 className="size-3" />
-                  </button>
-                </div>
-              )}
-            </div>
           </div>
 
           <div className="flex-1 flex justify-end">
@@ -160,59 +69,15 @@ function Toolbar({
           </div>
         </div>
 
-        {/* Mobile layout - three rows */}
+        {/* Mobile layout - two rows */}
         <div className="flex flex-col lg:hidden rounded-lg px-4" role="group">
           {/* First row - status indicator only */}
-          <div className="inline-flex items-center justify-center mb-2">
+          <div className="inline-flex items-center justify-center mb-0">
             <StatusIndicator error={error} isLoading={isLoading} pageRendered={pageRendered} />
           </div>
 
-          {/* Second row - resume name editor */}
-          <div className="flex items-center justify-center mb-2">
-            {isEditingName ? (
-              <div className="flex items-center space-x-1">
-                <input
-                  ref={inputRef}
-                  type="text"
-                  value={tempName}
-                  onChange={(e) => setTempName(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="px-2 py-1 text-sm bg-white dark:bg-zinc-700 border border-gray-300 dark:border-zinc-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-500 min-w-[200px]"
-                  placeholder="Resume name"
-                />
-                <button
-                  onClick={handleSaveEdit}
-                  className="p-1 text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300"
-                  title="Save name"
-                >
-                  <Check className="size-4" />
-                </button>
-                <button
-                  onClick={handleCancelEdit}
-                  className="p-1 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                  title="Cancel edit"
-                >
-                  <X className="size-4" />
-                </button>
-              </div>
-            ) : (
-              <div className="flex items-center space-x-1 group">
-                <span className="text-sm text-gray-700 dark:text-gray-300 font-medium">
-                  {resumeName}
-                </span>
-                <button
-                  onClick={handleStartEdit}
-                  className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-                  title="Edit resume name"
-                >
-                  <Edit2 className="size-3" />
-                </button>
-              </div>
-            )}
-          </div>
-
-          {/* Third row - buttons */}
-          <div className="flex flex-row justify-center items-center">
+          {/* Second row - buttons right */}
+          <div className="flex flex-row justify-between items-center">
 
             <div className="inline-flex">
               <button type="button"

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,23 @@
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from "next-themes"
 import { Toaster as Sonner, ToasterProps } from "sonner"
+import React from "react"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()

--- a/src/lib/ImportExportService.ts
+++ b/src/lib/ImportExportService.ts
@@ -1,5 +1,5 @@
 import { FormData, GenericSection } from '../types';
-import { getSavedResumes, loadResumeCopy } from './StorageService';
+import { getSavedResumes, loadResumeCopy, updateOrCreateResumeCopy } from './StorageService';
 
 interface JsonResumeBasics {
   name: string;
@@ -431,4 +431,88 @@ export const downloadAllResumesAsJson = (): void => {
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
+};
+
+interface ImportResult {
+  imported: number;
+  skipped: number;
+  renamed: number;
+}
+
+/**
+ * Import all resumes from a JSON file using suffix strategy for conflicts
+ * @returns Promise that resolves with import statistics
+ */
+export const importAllResumesFromJson = async (file: File): Promise<ImportResult> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    
+    reader.onload = (e) => {
+      try {
+        const importData: AllResumesExport = JSON.parse(e.target?.result as string);
+        
+        if (!importData.resumes || !Array.isArray(importData.resumes)) {
+          throw new Error('Invalid import file format');
+        }
+        
+        const existingResumes = getSavedResumes();
+        const existingNames = new Set(existingResumes.map(r => r.name));
+        
+        let imported = 0;
+        let skipped = 0;
+        let renamed = 0;
+        
+        importData.resumes.forEach(exportedResume => {
+          try {
+            // Import the form data from JSON Resume format
+            const formData = importFromJsonResume(exportedResume.jsonResume);
+            let finalName = exportedResume.name;
+            
+            // Check for name conflicts
+            if (existingNames.has(finalName)) {
+              // Find a unique name with suffix
+              let suffix = 1;
+              let newName = `${finalName} (imported)`;
+              while (existingNames.has(newName)) {
+                suffix++;
+                newName = `${finalName} (imported ${suffix})`;
+              }
+              finalName = newName;
+              renamed++;
+            }
+            
+            // Create the resume with a new ID (don't reuse the exported ID to avoid conflicts)
+            const newId = crypto.randomUUID();
+            updateOrCreateResumeCopy(
+              newId,
+              {
+                formData,
+                sections: [], // This will be populated by the app when the resume is loaded
+                templateId: exportedResume.templateId,
+                currentResumeId: newId
+              },
+              finalName
+            );
+            
+            existingNames.add(finalName);
+            imported++;
+          } catch (error) {
+            console.error(`Failed to import resume "${exportedResume.name}":`, error);
+            skipped++;
+          }
+        });
+        
+        resolve({ imported, skipped, renamed });
+      } catch (error) {
+        if (error instanceof Error) {
+          reject(new Error(error.message));
+        } else {
+          reject(new Error('Failed to parse import file'));
+        }
+      }
+    };
+    
+    reader.onerror = () => reject(new Error('Failed to read import file'));
+    reader.readAsText(file);
+  });
 }; 

--- a/src/lib/ResumeContext.tsx
+++ b/src/lib/ResumeContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { FormData, Section } from '../types';
-import { loadFromStorage, saveToStorage, generateDefaultResumeName } from './StorageService';
+import { loadFromStorage, saveToStorage, generateDefaultResumeName, updateOrCreateResumeCopy } from './StorageService';
 import { TemplateFactory, TemplateInfo } from '@/lib/LaTeX/TemplateFactory';
 
 interface ResumeContextType {
@@ -8,10 +8,12 @@ interface ResumeContextType {
   sections: Section[];
   selectedTemplate: TemplateInfo;
   resumeName: string;
+  currentResumeId?: string;
   setFormData: (data: FormData) => void;
   setSections: (sections: Section[]) => void;
   setSelectedTemplate: (template: TemplateInfo) => void;
   setResumeName: (name: string) => void;
+  setCurrentResumeId: (id: string | undefined) => void;
   handleChange: (section: string, field: string, value: string | string[]) => void;
   handleSectionSelected: (sectionId: string, checked: boolean) => void;
   handleSectionRemoved: (sectionId: string) => void;
@@ -23,7 +25,7 @@ const ResumeContext = createContext<ResumeContextType | undefined>(undefined);
 
 export function ResumeProvider({ children }: { children: ReactNode }) {
   // Load data from localStorage or use initial data
-  const { formData: savedFormData, sections: savedSections, templateId: savedTemplateId, resumeName: savedResumeName } = loadFromStorage();
+  const { formData: savedFormData, sections: savedSections, templateId: savedTemplateId, resumeName: savedResumeName, currentResumeId: savedCurrentResumeId } = loadFromStorage();
 
   const [formData, setFormData] = useState<FormData>(savedFormData);
   const [sections, setSections] = useState<Section[]>(savedSections);
@@ -33,15 +35,26 @@ export function ResumeProvider({ children }: { children: ReactNode }) {
   const [resumeName, setResumeName] = useState<string>(
     savedResumeName || generateDefaultResumeName(savedFormData)
   );
+  const [currentResumeId, setCurrentResumeId] = useState<string | undefined>(
+    savedCurrentResumeId || crypto.randomUUID()
+  );
 
   useEffect(() => {
     persistChangesOnChange();
 
     function persistChangesOnChange() {
       const templateId: string = selectedTemplate.id;
-      saveToStorage({ formData, sections, templateId, resumeName });
+      const dataToSave = { formData, sections, templateId, resumeName, currentResumeId };
+      
+      // Save to working storage
+      saveToStorage(dataToSave);
+      
+      // Also save/update in saved copies if we have a currentResumeId
+      if (currentResumeId) {
+        updateOrCreateResumeCopy(currentResumeId, dataToSave, resumeName);
+      }
     }
-  }, [formData, sections, selectedTemplate, resumeName]);
+  }, [formData, sections, selectedTemplate, resumeName, currentResumeId]);
 
   const handleChange = (section: string, field: string, value: string | string[]): void => {
     setFormData(prevData => ({
@@ -114,10 +127,12 @@ export function ResumeProvider({ children }: { children: ReactNode }) {
         sections,
         selectedTemplate,
         resumeName,
+        currentResumeId,
         setFormData,
         setSections,
         setSelectedTemplate,
         setResumeName,
+        setCurrentResumeId,
         handleChange,
         handleSectionSelected,
         handleSectionRemoved,

--- a/src/lib/StorageService.ts
+++ b/src/lib/StorageService.ts
@@ -2,11 +2,24 @@ import { FormData, Section } from '../types';
 import { initialFormData, initialSections, initialTemplateId } from './DataInitializer';
 
 export const STORAGE_KEY = 'resume-builder-data';
+export const SAVED_RESUMES_KEY = 'resume-builder-saved-copies';
 
 interface StoredData {
   formData: FormData;
   sections: Section[];
   templateId?: string;
+  resumeName?: string;
+}
+
+interface SavedResumeMetadata {
+  id: string;
+  name: string;
+  createdAt: string;
+  lastUpdated: string;
+}
+
+interface SavedResume extends SavedResumeMetadata {
+  data: StoredData;
 }
 
 /**
@@ -23,6 +36,7 @@ export const loadFromStorage = (): StoredData => {
         formData: parsedData.formData || initialFormData,
         sections: parsedData.sections || initialSections,
         templateId: parsedData.templateId || initialTemplateId,
+        resumeName: parsedData.resumeName,
       };
     }
   } catch (error) {
@@ -52,7 +66,7 @@ export const saveToStorage = (data: StoredData): void => {
  * Clear all stored data and return to initial defaults
  * @returns Object containing initial formData and sections
  */
-export const clearStorage = (targetFormData: FormData = initialFormData, targetSections: Section[] = initialSections, targetTemplateId: string = initialTemplateId): StoredData => {
+export const clearStorage = (targetFormData: FormData = initialFormData, targetSections: Section[] = initialSections, targetTemplateId: string = initialTemplateId, targetResumeName?: string): StoredData => {
   try {
     localStorage.removeItem(STORAGE_KEY);
   } catch (error) {
@@ -62,6 +76,162 @@ export const clearStorage = (targetFormData: FormData = initialFormData, targetS
   return {
     formData: targetFormData,
     sections: targetSections,
-    templateId: targetTemplateId
+    templateId: targetTemplateId,
+    resumeName: targetResumeName
   };
+};
+
+/**
+ * Generate a default name for a resume based on personal info
+ * @param formData The form data to extract name from
+ * @returns A default resume name in kebab-case with epoch timestamp
+ */
+export const generateDefaultResumeName = (formData: FormData): string => {
+  const { personalInfo } = formData;
+  const epochSeconds = Math.floor(Date.now() / 1000);
+  
+  if (personalInfo?.name && personalInfo?.name !== 'Your Name') {
+    // Convert name to kebab-case: "John Doe" -> "john-doe"
+    const kebabName = personalInfo.name
+      .toLowerCase()
+      .trim()
+      .replace(/[^\w\s-]/g, '') // Remove special characters
+      .replace(/\s+/g, '-'); // Replace spaces with hyphens
+    
+    return `${kebabName}-resume-${epochSeconds}`;
+  }
+  
+  return `my-resume-${epochSeconds}`;
+};
+
+/**
+ * Get all saved resume copies from localStorage
+ * @returns Array of saved resume metadata, sorted by lastUpdated (newest first)
+ */
+export const getSavedResumes = (): SavedResumeMetadata[] => {
+  try {
+    const savedData = localStorage.getItem(SAVED_RESUMES_KEY);
+    if (savedData) {
+      const resumes: SavedResume[] = JSON.parse(savedData);
+      return resumes
+        .map(resume => ({
+          id: resume.id,
+          name: resume.name,
+          createdAt: resume.createdAt,
+          lastUpdated: resume.lastUpdated
+        }))
+        .sort((a, b) => new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime());
+    }
+  } catch (error) {
+    console.error('Error loading saved resumes:', error);
+  }
+  return [];
+};
+
+/**
+ * Save a copy of the current resume with a given name
+ * @param data The resume data to save
+ * @param name The name for this resume copy
+ * @returns The ID of the saved resume
+ */
+export const saveResumeCopy = (data: StoredData, name?: string): string => {
+  try {
+    const resumeId = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const resumeName = name || generateDefaultResumeName(data.formData);
+    
+    const savedResume: SavedResume = {
+      id: resumeId,
+      name: resumeName,
+      createdAt: now,
+      lastUpdated: now,
+      data
+    };
+    
+    const existingResumes = getSavedResumesFull();
+    const updatedResumes = [...existingResumes, savedResume];
+    
+    localStorage.setItem(SAVED_RESUMES_KEY, JSON.stringify(updatedResumes));
+    return resumeId;
+  } catch (error) {
+    console.error('Error saving resume copy:', error);
+    throw new Error('Failed to save resume copy');
+  }
+};
+
+/**
+ * Load a saved resume copy by ID
+ * @param id The ID of the resume to load
+ * @returns The stored data or null if not found
+ */
+export const loadResumeCopy = (id: string): StoredData | null => {
+  try {
+    const savedResumes = getSavedResumesFull();
+    const resume = savedResumes.find(r => r.id === id);
+    return resume ? resume.data : null;
+  } catch (error) {
+    console.error('Error loading resume copy:', error);
+    return null;
+  }
+};
+
+/**
+ * Delete a saved resume copy by ID
+ * @param id The ID of the resume to delete
+ * @returns True if successfully deleted, false otherwise
+ */
+export const deleteResumeCopy = (id: string): boolean => {
+  try {
+    const savedResumes = getSavedResumesFull();
+    const filteredResumes = savedResumes.filter(r => r.id !== id);
+    
+    if (filteredResumes.length === savedResumes.length) {
+      return false; // Resume not found
+    }
+    
+    localStorage.setItem(SAVED_RESUMES_KEY, JSON.stringify(filteredResumes));
+    return true;
+  } catch (error) {
+    console.error('Error deleting resume copy:', error);
+    return false;
+  }
+};
+
+/**
+ * Update the name of a saved resume copy
+ * @param id The ID of the resume to rename
+ * @param newName The new name for the resume
+ * @returns True if successfully renamed, false otherwise
+ */
+export const renameResumeCopy = (id: string, newName: string): boolean => {
+  try {
+    const savedResumes = getSavedResumesFull();
+    const resumeIndex = savedResumes.findIndex(r => r.id === id);
+    
+    if (resumeIndex === -1) {
+      return false; // Resume not found
+    }
+    
+    savedResumes[resumeIndex].name = newName;
+    savedResumes[resumeIndex].lastUpdated = new Date().toISOString();
+    
+    localStorage.setItem(SAVED_RESUMES_KEY, JSON.stringify(savedResumes));
+    return true;
+  } catch (error) {
+    console.error('Error renaming resume copy:', error);
+    return false;
+  }
+};
+
+/**
+ * Helper function to get full saved resumes data (internal use)
+ */
+const getSavedResumesFull = (): SavedResume[] => {
+  try {
+    const savedData = localStorage.getItem(SAVED_RESUMES_KEY);
+    return savedData ? JSON.parse(savedData) : [];
+  } catch (error) {
+    console.error('Error loading saved resumes:', error);
+    return [];
+  }
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import { Toaster } from 'sonner'
 
 createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>
     <App />
+    <Toaster position="top-left" />
   </StrictMode>,
 )

--- a/src/views/Editor.tsx
+++ b/src/views/Editor.tsx
@@ -146,12 +146,15 @@ function Editor() {
   };
 
   const loadImportedJsonResume = (importedFormData: FormData) => {
-    if (!window.confirm('Loading imported resume data will overwrite any edits you have made. This cannot be undone. Would you like to proceed?')) {
-      return;
-    }
-
+    // Create a new resume with the imported data
+    const newResumeId = crypto.randomUUID();
+    const newResumeName = generateDefaultResumeName(importedFormData);
+    
+    // Set all the state to switch to this new resume
     setFormData(importedFormData);
     setSections(createSectionsFromFormData(importedFormData));
+    setCurrentResumeId(newResumeId);
+    setResumeName(newResumeName);
   };
 
   const sortedSections = [...sections].sort((a, b) => a.sortOrder - b.sortOrder);

--- a/src/views/Editor.tsx
+++ b/src/views/Editor.tsx
@@ -141,14 +141,8 @@ function Editor() {
     if (!window.confirm('Loading sample data will overwrite any edits you have made. This cannot be undone. Would you like to proceed?')) {
       return;
     }
-
-    const newResumeId = crypto.randomUUID();
-    const newResumeName = generateDefaultResumeName(sampleFormData);
-    
     setFormData(sampleFormData);
     setSections(createSectionsFromFormData(sampleFormData));
-    setCurrentResumeId(newResumeId);
-    setResumeName(newResumeName);
   };
 
   const loadImportedJsonResume = (importedFormData: FormData) => {

--- a/src/views/Editor.tsx
+++ b/src/views/Editor.tsx
@@ -15,7 +15,7 @@ import { createSectionsFromFormData, initialFormData, sampleFormData } from '@/l
 import { generateDefaultResumeName } from '@/lib/StorageService';
 import Projects from './forms/Projects';
 import GenericSection from './forms/GenericSection';
-import { downloadResumeAsJson } from '@/lib/ImportExportService';
+import { downloadResumeAsJson, downloadAllResumesAsJson } from '@/lib/ImportExportService';
 import { useResume } from '@/lib/ResumeContext';
 import Reference from './forms/Reference';
 
@@ -168,6 +168,7 @@ function Editor() {
           resetData={() => resetToDefaults() }
           sampleData={() => resetToSampleData() }
           onExport={() => downloadResumeAsJson(formData) }
+          onExportAll={() => downloadAllResumesAsJson() }
           onImportJsonFormData={formData => loadImportedJsonResume(formData) }
         />
         <div className="grid lg:grid-cols-12 grid-cols-12 gap-0 w-full h-screen">

--- a/src/views/Editor.tsx
+++ b/src/views/Editor.tsx
@@ -12,6 +12,7 @@ import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
 import AppSidebar from '@/components/AppSidebar';
 import Navbar from '@/components/Navbar';
 import { createSectionsFromFormData, initialFormData, sampleFormData } from '@/lib/DataInitializer';
+import { generateDefaultResumeName } from '@/lib/StorageService';
 import Projects from './forms/Projects';
 import GenericSection from './forms/GenericSection';
 import { downloadResumeAsJson } from '@/lib/ImportExportService';
@@ -34,6 +35,8 @@ function Editor() {
     sections,
     setFormData,
     setSections,
+    setCurrentResumeId,
+    setResumeName,
   } = useResume();
 
   const sectionRenderMapping = useMemo<SectionRenderItem[]>(() => [
@@ -125,8 +128,13 @@ function Editor() {
       return;
     }
 
+    const newResumeId = crypto.randomUUID();
+    const newResumeName = generateDefaultResumeName(initialFormData);
+    
     setFormData(initialFormData);
     setSections(createSectionsFromFormData(initialFormData));
+    setCurrentResumeId(newResumeId);
+    setResumeName(newResumeName);
   };
 
   const resetToSampleData = () => {
@@ -134,8 +142,13 @@ function Editor() {
       return;
     }
 
+    const newResumeId = crypto.randomUUID();
+    const newResumeName = generateDefaultResumeName(sampleFormData);
+    
     setFormData(sampleFormData);
     setSections(createSectionsFromFormData(sampleFormData));
+    setCurrentResumeId(newResumeId);
+    setResumeName(newResumeName);
   };
 
   const loadImportedJsonResume = (importedFormData: FormData) => {

--- a/src/views/Preview.tsx
+++ b/src/views/Preview.tsx
@@ -9,7 +9,7 @@ import { usePdfRenderer } from "../lib/hooks/PdfRenderer";
 const MAX_WIDTH = 800;
 
 function Preview() {
-  const { formData, sections, selectedTemplate, resumeName, setResumeName } = useResume();
+  const { formData, sections, selectedTemplate } = useResume();
   const [containerHeight, setContainerHeight] = useState<number | null>(null);
   const [canvasWidthPx, setCanvasWidthPx] = useState<number>(MAX_WIDTH);
 
@@ -120,10 +120,8 @@ function Preview() {
           error={error} 
           isLoading={isCompiling} 
           pageRendered={pdfDoc !== null}
-          resumeName={resumeName}
           onDownloadPdf={downloadPdf}
           onDownloadLaTeX={downloadLaTeX}
-          onResumeNameChange={setResumeName}
         />
       </div>
 

--- a/src/views/Preview.tsx
+++ b/src/views/Preview.tsx
@@ -9,7 +9,7 @@ import { usePdfRenderer } from "../lib/hooks/PdfRenderer";
 const MAX_WIDTH = 800;
 
 function Preview() {
-  const { formData, sections, selectedTemplate } = useResume();
+  const { formData, sections, selectedTemplate, resumeName, setResumeName } = useResume();
   const [containerHeight, setContainerHeight] = useState<number | null>(null);
   const [canvasWidthPx, setCanvasWidthPx] = useState<number>(MAX_WIDTH);
 
@@ -120,8 +120,10 @@ function Preview() {
           error={error} 
           isLoading={isCompiling} 
           pageRendered={pdfDoc !== null}
+          resumeName={resumeName}
           onDownloadPdf={downloadPdf}
           onDownloadLaTeX={downloadLaTeX}
+          onResumeNameChange={setResumeName}
         />
       </div>
 

--- a/test/lib/ResumeContext.test.tsx
+++ b/test/lib/ResumeContext.test.tsx
@@ -3,9 +3,21 @@ import { ResumeProvider, useResume } from '@/lib/ResumeContext';
 import { loadFromStorage, saveToStorage } from '@/lib/StorageService';
 import { TemplateFactory } from '@/lib/LaTeX/TemplateFactory';
 
+// Mock crypto.randomUUID which is not available in test environment
+beforeAll(() => {
+  Object.defineProperty(global, 'crypto', {
+    value: {
+      randomUUID: jest.fn(() => 'test-uuid-123'),
+    },
+    writable: true,
+  });
+});
+
 jest.mock('@/lib/StorageService', () => ({
   loadFromStorage: jest.fn(),
   saveToStorage: jest.fn(),
+  generateDefaultResumeName: jest.fn(() => 'test-resume-123456'),
+  updateOrCreateResumeCopy: jest.fn(),
 }));
 
 jest.mock('@/lib/LaTeX/TemplateFactory', () => ({


### PR DESCRIPTION
## Added
- Multiple resume support - Users can now manage multiple resumes with automatic saving
- Resume management UI - New dropdown menu in sidebar with New, Open, and Save As Copy options
- Auto-save functionality - All changes automatically saved to both working storage and resume collection
- Export/Import All - Bulk export/import for all resumes with conflict resolution
- Resume switching - Seamless switching between resumes without confirmation prompts
- Template persistence - Theme/template selection saved per resume

## Changed
- Import behavior - "Import Single" now creates a new resume instead of replacing current
- Storage architecture - Dual storage system for working resume and saved copies
- Alert component - Now accepts ReactNode for rich content display

## Details
- Each resume has a unique ID (currentResumeId) for reliable tracking
- "Save As Copy" uses auto-incrementing names: resume-name (1), resume-name (2)
- Import conflicts resolved with suffix strategy: resume-name (imported)

## UI Improvements
- Export/Import consolidated into dropdown menus for cleaner interface
- Removed redundant "Clear Form" option
- Current resume protected from deletion/reload in Open dialog
- Better scroll styling and visual consistency